### PR TITLE
fix: 게시글 댓글 작성 기능 버그 수정

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/board/command/application/controller/PostCommentController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/board/command/application/controller/PostCommentController.java
@@ -1,7 +1,7 @@
 package com.matzip.matzipback.board.command.application.controller;
 
-import com.matzip.matzipback.board.command.application.dto.PostCommentResponseDTO;
 import com.matzip.matzipback.board.command.application.dto.RequestPostCommentDTO;
+import com.matzip.matzipback.board.command.application.dto.ResponsePostCommentDTO;
 import com.matzip.matzipback.board.command.application.service.PostCommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,8 +19,8 @@ public class PostCommentController {
 
     // 댓글 등록
     @PostMapping("/postComment")
-    public ResponseEntity<PostCommentResponseDTO> createPostComment(@RequestBody RequestPostCommentDTO requestPostCommentDTO) {
-        PostCommentResponseDTO postComment = postCommentService.createPostComment(requestPostCommentDTO);
+    public ResponseEntity<ResponsePostCommentDTO> createPostComment(@RequestBody RequestPostCommentDTO requestPostCommentDTO) {
+        ResponsePostCommentDTO postComment = postCommentService.createPostComment(requestPostCommentDTO);
 
         return ResponseEntity.ok(postComment);
     }

--- a/matzipback/src/main/java/com/matzip/matzipback/board/command/application/service/PostCommentService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/board/command/application/service/PostCommentService.java
@@ -25,13 +25,12 @@ public class PostCommentService {
         PostComment postComment = PostComment.create(requestPostCommentDTO, userSeq);
 
         // 댓글 저장
-        Optional<PostComment> optionalSavedPC = postCommentRepository.save(postComment);
+        PostComment savedPostComment = postCommentRepository.save(postComment);
 
         // null 체크 및 처리
-        if (!optionalSavedPC.isPresent()) {
+        if (savedPostComment == null) {
             throw new RuntimeException("댓글 저장에 실패했습니다."); // 예외 처리
         }
-        PostComment savedPostComment = optionalSavedPC.get();
 
         // DTO로 변환하여 반환
         ResponsePostCommentDTO responseDTO = new ResponsePostCommentDTO();

--- a/matzipback/src/main/java/com/matzip/matzipback/board/command/domain/repository/PostCommentRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/board/command/domain/repository/PostCommentRepository.java
@@ -1,11 +1,7 @@
 package com.matzip.matzipback.board.command.domain.repository;
 
 import com.matzip.matzipback.board.command.domain.aggregate.PostComment;
-import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
-@Repository
 public interface PostCommentRepository {
-    Optional<PostComment> save(PostComment postComment);
+    PostComment save(PostComment postComment);
 }


### PR DESCRIPTION
🌟개요
---
Repository 상속과정에서 JspRepo의 save메서드와 PostCommentRepo의 save메서드의 반환형이 다름으로 인한 오류 발생

🌐연결된 Issues
---
#99 

📋작업사항
---
PostCommentRepository 빈 등록 수정

✏️작성한 이슈 외 작업사항
---
PostCommentController 클래스 내의 ResponsePostCommentDTO 오타 수정

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
