### PR TITLE
fix: #23 리스트 등록 시 level 자동 생성 로직 변경

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/ListCommandService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/ListCommandService.java
@@ -10,12 +10,13 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ListCommandService {
 
         private final ListDomainRepository listDomainRepository;
-        private final ListQueryMapper listQueryMapper;
 
     @Transactional
     public Long createList(CreateListRequest listRequest) {
@@ -24,9 +25,12 @@ public class ListCommandService {
 //        Long listUserSeq = CustomUserUtils.getCurrentUserSeq();
 
         // 테스트용 코드 생성 (권한이 없는 유저 시퀀스)
-        long listUserSeq = 3L;
+        long listUserSeq = 4L;
+        // 특정 유저의 리스트 서랍에 있는 리스트 카운트
+        long countListLevel = listDomainRepository.countByListUserSeq(listUserSeq);
 
-        int listLevel = listQueryMapper.getCountList(listUserSeq);
+        // 카운트 된 리스트 개수에 + 1을 더해서 1부터 입력되게 설정
+        int listLevel = (int) countListLevel + 1;
 
         MyList newList = ListMapper.toEntity(listRequest, listUserSeq, listLevel);
 

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/ListDomainRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/ListDomainRepository.java
@@ -14,4 +14,6 @@ public interface ListDomainRepository {
 
     MyList save(MyList myList);
 
+    long countByListUserSeq(Long listUserSeq);
+
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListQueryController.java
@@ -1,8 +1,6 @@
 package com.matzip.matzipback.matzipList.query.controller;
 
-import com.matzip.matzipback.board.query.controller.BoardQueryController;
 import com.matzip.matzipback.common.util.CustomUserUtils;
-import com.matzip.matzipback.matzipList.query.dto.ListCategoryDTO;
 import com.matzip.matzipback.matzipList.query.dto.ListSearchAllDTO;
 import com.matzip.matzipback.matzipList.query.service.ListQueryService;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
🌟개요
리스트 등록 시 리스트 레벨 자동 생성 로직 변경

🌐연결된 Issues
#23 

📋작업사항
리스트 등록 로직은 JPA로 짜였지만 list_level을 자동생성하는 조회 기능은 Mybatis로 구현되어서 이를 JPA로 구현하도록 수정함.

✏️작성한 이슈 외 작업사항
List Query 에 Controller에 있는 코드 정리

✅체크리스트
---
- [x] PR 규칙을 준수하였는가?
- [x] 이슈번호를 작성하였는가?
- [x] 추가/수정 사항을 설명하였는가?
