### PR TITLE
feat: #127 다른 유저의 리스트 서랍 조회 기능 구현

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListQueryController.java
@@ -2,6 +2,7 @@ package com.matzip.matzipback.matzipList.query.controller;
 
 import com.matzip.matzipback.common.util.CustomUserUtils;
 import com.matzip.matzipback.matzipList.query.dto.ListSearchAllDTO;
+import com.matzip.matzipback.matzipList.query.dto.ListSearchUserDTO;
 import com.matzip.matzipback.matzipList.query.service.ListQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,9 @@ public class ListQueryController {
         return ResponseEntity.ok().body(listQueryService.getListBox(listUserSeq));
     }
 
-
+    @GetMapping("/listBox/{listUserSeq}")
+    public ResponseEntity<List<ListSearchUserDTO>> getUserListBox(@PathVariable("listUserSeq") Long listUserSeq) {
+        return ResponseEntity.ok().body(listQueryService.getUserListBox(listUserSeq));
+    }
 
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/dto/ListSearchUserDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/dto/ListSearchUserDTO.java
@@ -1,0 +1,11 @@
+package com.matzip.matzipback.matzipList.query.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ListSearchUserDTO {
+    private String listTitle;
+    private long listLevel;
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/mapper/ListQueryMapper.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/mapper/ListQueryMapper.java
@@ -1,6 +1,7 @@
 package com.matzip.matzipback.matzipList.query.mapper;
 
 import com.matzip.matzipback.matzipList.query.dto.ListSearchAllDTO;
+import com.matzip.matzipback.matzipList.query.dto.ListSearchUserDTO;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -10,8 +11,5 @@ public interface ListQueryMapper {
 
     List<ListSearchAllDTO> getListBox(long listUserSeq);
 
-    int getCountList(long listUserSeq); // 각 사용자의 리스트 개수 구하기
-
-
-
+    List<ListSearchUserDTO> getUserListBox(Long listUserSeq);
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/service/ListQueryService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/service/ListQueryService.java
@@ -1,7 +1,7 @@
 package com.matzip.matzipback.matzipList.query.service;
 
-import com.matzip.matzipback.matzipList.query.dto.ListCategoryDTO;
 import com.matzip.matzipback.matzipList.query.dto.ListSearchAllDTO;
+import com.matzip.matzipback.matzipList.query.dto.ListSearchUserDTO;
 import com.matzip.matzipback.matzipList.query.mapper.ListQueryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +19,7 @@ public class ListQueryService {
     }
 
 
-
-
-
+    public List<ListSearchUserDTO> getUserListBox(Long listUserSeq) {
+        return listQueryMapper.getUserListBox(listUserSeq);
+    }
 }

--- a/matzipback/src/main/resources/mappers/listMappers/ListQueryMapper.xml
+++ b/matzipback/src/main/resources/mappers/listMappers/ListQueryMapper.xml
@@ -5,13 +5,6 @@
 
 <mapper namespace="com.matzip.matzipback.matzipList.query.mapper.ListQueryMapper">
 
-    <!-- 사용자 리스트 개수 조회 -->
-    <select id="getCountList" resultType="int">
-        SELECT COUNT(*)
-          FROM lists
-         WHERE list_user_seq = #{listUserSeq}
-    </select>
-
     <select  id="getListBox" resultType="com.matzip.matzipback.matzipList.query.dto.ListSearchAllDTO">
         SELECT
             list_title,
@@ -23,6 +16,20 @@
 
         ORDER BY
             list_level ASC
+    </select>
+
+    <select  id="getUserListBox" resultType="com.matzip.matzipback.matzipList.query.dto.ListSearchUserDTO">
+        SELECT
+               list_title,
+               list_level
+          FROM
+               lists
+         WHERE
+               list_user_seq = #{listUserSeq}
+               AND list_status = 'active'
+        ORDER BY
+               list_level ASC
+
     </select>
 
 </mapper>


### PR DESCRIPTION
🌟개요
다른 유저의 리스트 서랍 조회하는 기능 구현

🌐연결된 Issues
#127 다른 유저의 리스트 서랍 조회

📋작업사항
다른 유저의 리스트 서랍을 조회하는 기능 구현

- 기존 리스트 서랍 조회와의 차이점
  list_status 가 active인 리스트만 조회 됨

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
