### PR TITLE
fix: 댓글 수정 로직 수정

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/board/command/application/dto/ReqPostCmtCreateDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/board/command/application/dto/ReqPostCmtCreateDTO.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Setter
 public class ReqPostCmtCreateDTO {
 
+    private Long postCommentUserSeq;
     private Long postSeq;
     private String postCommentContent;
 

--- a/matzipback/src/main/java/com/matzip/matzipback/board/command/application/service/PostCommentService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/board/command/application/service/PostCommentService.java
@@ -61,13 +61,11 @@ public class PostCommentService {
         PostComment postComment = postCommentInfraRepository.findById(postCommentSeq)
                 .orElseThrow(NoSuchElementException::new);
 
-        // 댓글 Status가 inactive일 경우 예외 처리
-//        String postCommentStatus = postComment.getPostCommentStatus();
-//        if (postCommentStatus.equals("inactive")) {
-//            throw new RuntimeException("삭제된 댓글입니다.");
-//        }
+        // DB내 작성된 댓글 수정 (수정 전 입력 값과 동일하면 안된다.)
+        if (postComment.getPostCommentContent().equals(reqPostCmtUpdateDTO.getPostCommentContent())) {
+            throw new RuntimeException("댓글 수정에 실패했습니다."); // 예외 처리
+        }
 
-        // DB내 작성된 댓글 수정
         postComment.updatePostCmt(reqPostCmtUpdateDTO.getPostCommentContent());
         // 수정 값이 자동으로 업데이트 시에 @LastModifiedDate가 적용
 

--- a/matzipback/src/main/java/com/matzip/matzipback/board/command/domain/aggregate/PostComment.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/board/command/domain/aggregate/PostComment.java
@@ -48,20 +48,16 @@ public class PostComment {
         if(postCommentStatus == null) {
             postCommentStatus = "active";
         }
-
-//        if (postCommentCreatedTime == null) {
-//            postCommentCreatedTime = LocalDateTime.now();
-//        }
     }
 
     // DTO -> Entity (생성자 사용을 안하려고 따로 만든 메서드)
-    public static PostComment create(ReqPostCmtCreateDTO reqPostCmtDTO, Long userSeq) {
-        return new PostComment(
-                reqPostCmtDTO.getPostSeq(),
-                userSeq,
-                reqPostCmtDTO.getPostCommentContent()
-        );
-    }
+//    public static PostComment create(ReqPostCmtCreateDTO reqPostCmtDTO, Long userSeq) {
+//        return new PostComment(
+//                reqPostCmtDTO.getPostSeq(),
+//                userSeq,
+//                reqPostCmtDTO.getPostCommentContent()
+//        );
+//    }
 
     // 요청 받은 댓글 내용을 기존 댓글에서 수정
     public void updatePostCmt(String postCommentContent) {

--- a/matzipback/src/main/java/com/matzip/matzipback/like/command/application/controller/PostCmtLikeController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/like/command/application/controller/PostCmtLikeController.java
@@ -13,7 +13,7 @@ public class PostCmtLikeController {
     private final PostCmtLikeService postCmtLikeService;
 
     // 게시글 댓글 좋아요
-    @PostMapping("/{postSeq}/postcomment/{postcommentSeq}/like")
+    @PostMapping("/{postSeq}/postcomment/{postCommentSeq}/like")
     public ResponseEntity<Long> toggleLike(
             @PathVariable Long postSeq,
             @PathVariable Long postCommentSeq


### PR DESCRIPTION
🌟개요
---
댓글 수정 시 수정 값과 기존 값이 동일해도 불필요한 DB 수정 과정이 발생한다.

🌐연결된 Issues
---
#147 
#105 

📋작업사항
---
댓글 수정 시 수정 값과 기존 값이 동일할 경우 예외를 발생시키도록 로직 수정

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
