### PR TITLE
feat: #29 리스트 내 맛집 검색 기능 구현

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/MatzipQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/MatzipQueryController.java
@@ -1,0 +1,26 @@
+package com.matzip.matzipback.matzipList.query.controller;
+
+import com.matzip.matzipback.matzipList.query.dto.MatzipSearchDTO;
+import com.matzip.matzipback.matzipList.query.service.MatzipQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MatzipQueryController {
+
+    private final MatzipQueryService matzipQueryService;
+
+    @GetMapping("list/{listSeq}/restaurants")
+    public ResponseEntity<List<MatzipSearchDTO>> getMatzip(
+            @PathVariable Long listSeq,
+            @RequestParam(value = "matzipTitle", required = false) String matzipTitle){
+
+            List<MatzipSearchDTO> matzip = matzipQueryService.searchMatzip(listSeq, matzipTitle);
+            return ResponseEntity.ok(matzip);
+    }
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/MatzipQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/MatzipQueryController.java
@@ -15,7 +15,7 @@ public class MatzipQueryController {
 
     private final MatzipQueryService matzipQueryService;
 
-    @GetMapping("list/{listSeq}/restaurants")
+    @GetMapping("list/{listSeq}/matzip")
     public ResponseEntity<List<MatzipSearchDTO>> getMatzip(
             @PathVariable Long listSeq,
             @RequestParam(value = "matzipTitle", required = false) String matzipTitle){

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/dto/MatzipSearchDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/dto/MatzipSearchDTO.java
@@ -1,0 +1,13 @@
+package com.matzip.matzipback.matzipList.query.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MatzipSearchDTO {
+    private String restaurantTitle;
+    private String restaurantAddress;
+    private String restaurantPhone;
+    private Long restaurantStar;
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/mapper/MatzipQueryMapper.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/mapper/MatzipQueryMapper.java
@@ -1,0 +1,12 @@
+package com.matzip.matzipback.matzipList.query.mapper;
+
+import com.matzip.matzipback.matzipList.query.dto.MatzipSearchDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface MatzipQueryMapper {
+
+    List<MatzipSearchDTO> getMatzip(Long listSeq, String matzipTitle);
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/service/MatzipQueryService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/service/MatzipQueryService.java
@@ -1,0 +1,19 @@
+package com.matzip.matzipback.matzipList.query.service;
+
+import com.matzip.matzipback.matzipList.query.dto.MatzipSearchDTO;
+import com.matzip.matzipback.matzipList.query.mapper.MatzipQueryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MatzipQueryService {
+
+    private final MatzipQueryMapper matzipQueryMapper;
+
+    public List<MatzipSearchDTO> searchMatzip(Long listSeq, String matzipTitle) {
+        return matzipQueryMapper.getMatzip(listSeq, matzipTitle);
+    }
+}

--- a/matzipback/src/main/resources/mappers/listMappers/MatzipQueryMapper.xml
+++ b/matzipback/src/main/resources/mappers/listMappers/MatzipQueryMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.matzip.matzipback.matzipList.query.mapper.MatzipQueryMapper">
+
+    <select  id="getMatzip" resultType="com.matzip.matzipback.matzipList.query.dto.MatzipSearchDTO">
+        SELECT
+               r.restaurant_title ,
+               r.restaurant_address ,
+               r.restaurant_phone ,
+               r.restaurant_star
+          FROM
+               list_matzip m
+          LEFT JOIN lists l ON m.list_seq = l.list_seq
+          LEFT JOIN restaurant r ON m.restaurant_seq = r.restaurant_seq
+         WHERE l.list_seq = #{listSeq} AND
+               (r.restaurant_title LIKE CONCAT('%' #{matzipTitle} '%') OR #{matzipTitle} IS NULL)
+         ORDER BY
+               l.list_title ASC;
+    </select>
+
+</mapper>


### PR DESCRIPTION
🌟개요
리스트 내 맛집 검색 기능 구현

🌐연결된 Issues
#29 

📋작업사항
리스트 내에 맛집을 조회하는 기능을 구현했습니다
음식점 조회와의 차이점은 WHERE 절로 2개의 조건을 추가한 것입니다.
1. listSeq 입력과 일치하는지
2. restaurantTitle과 일치하는지(LIKE문으로 한글자라도 포함되면 검색에 걸리도록 설정하였습니다)

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
