### PR TITLE
refactoring: 다른 유저도 팔로잉 목록을 조회할 수 있도록 수정

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersFollowQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersFollowQueryController.java
@@ -23,8 +23,8 @@ public class UsersFollowQueryController {
 
     // 내가 팔로우한 유저 조회 기능
     @GetMapping("/follow")
-    public ResponseEntity<FollowQueryResMessageDTO> searchFollowing(@RequestParam("page") int page) {
-        List<FollowingUsersDTO> followList = usersFollowQueryService.searchFollowingUsers(page);
+    public ResponseEntity<FollowQueryResMessageDTO> searchFollowing(@RequestParam("userSeq") long userSeq, @RequestParam("page") long page) {
+        List<FollowingUsersDTO> followList = usersFollowQueryService.searchFollowingUsers(userSeq, page);
 
         return ResponseEntity.ok(new FollowQueryResMessageDTO(HttpStatus.OK.value(), ResponseMessage.FOUND.getMessage(), followList));
     }

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersFollowMapper.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersFollowMapper.java
@@ -11,7 +11,7 @@ public interface UsersFollowMapper {
 
     List<FollowingUsersDTO> searchFollowUsersByUserSeqAndPage(
             @Param("followingUserSeq") long followingUserSeq,
-            @Param("offset") int offset,
+            @Param("offset") long offset,
             @Param("size") int size);
 
     long countFollowing(long followingUserSeq);

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersFollowQueryService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersFollowQueryService.java
@@ -13,26 +13,24 @@ public class UsersFollowQueryService {
 
     private final UsersFollowMapper usersFollowMapper;
 
-    public List<FollowingUsersDTO> searchFollowingUsers(int page) {
+    public List<FollowingUsersDTO> searchFollowingUsers(long userSeq, long page) {
 
-//        long followingUserSeq = CustomUserUtils.getCurrentUserSeq();
-        long followingUserSeq = 2L;
 
         if (page <= 0) {
             page = 1;
         }
 
-        int offset = (page - 1) * 10;
+        long offset = (page - 1) * 10;
         int size = 10;
 
-        long count = usersFollowMapper.countFollowing(followingUserSeq);
+        long count = usersFollowMapper.countFollowing(userSeq);
 
         if (offset > count) {
             page = (int) count / 10 + 1;
             offset = (page - 1) * 10;
         }
 
-        return usersFollowMapper.searchFollowUsersByUserSeqAndPage(followingUserSeq, offset, size);
+        return usersFollowMapper.searchFollowUsersByUserSeqAndPage(userSeq, offset, size);
     }
 
     public List<FollowingUsersDTO> searchFollowerUsers(long userSeq, long page) {


### PR DESCRIPTION
🌟개요
---
다른 유저도 팔로잉 목록을 조회할 수 있도록 수정

🌐연결된 Issues
---
#165 

📋작업사항
---
- 쿼리 파라미터에 userSeq 정보를 추가해서 요청에서 회원 고유번호를 받는다
- 회원 고유번호는 조회하려는 대상의 고유번호에 해당한다.

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
