### PR TITLE
feat: #79, #80 회원정보 수정, 탈퇴

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/exception/GlobalExceptionHandler.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.matzip.matzipback.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -13,6 +14,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
         // 예외 메시지를 클라이언트에 반환
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+    // MethodArgumentNotValidException 발생 시 메시지 반환
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        // 첫 번째 오류 메시지를 추출하여 응답
+        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity.badRequest().body(errorMessage);
     }
 
 

--- a/matzipback/src/main/java/com/matzip/matzipback/users/command/application/controller/UsersCommandController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/command/application/controller/UsersCommandController.java
@@ -1,13 +1,15 @@
 package com.matzip.matzipback.users.command.application.controller;
 
+import com.matzip.matzipback.common.util.CustomUserUtils;
 import com.matzip.matzipback.users.command.application.service.UsersCommandService;
 import com.matzip.matzipback.users.command.dto.CreateUserRequest;
+import com.matzip.matzipback.users.command.dto.DeleteUserRequest;
+import com.matzip.matzipback.users.command.dto.UpdateUserRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,21 +18,66 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class UsersCommandController {
 
-    private final UsersCommandService UsersCommandService;
+    private final UsersCommandService usersCommandService;
 
-    /* 회원가입 기능*/
+    /* 회원가입 기능 */
     @PostMapping("/auth/register")
-    public ResponseEntity<String> createUser(@Valid @RequestBody CreateUserRequest newUser, BindingResult bindingResult) {
-        // 유효성 검사 오류가 있는 경우 처리
-        if (bindingResult.hasErrors()) {
-            // 첫 번째 오류 메시지를 반환
-            String errorMessage = bindingResult.getAllErrors().get(0).getDefaultMessage();
-            return ResponseEntity.badRequest().body(errorMessage);
-        }
+    public ResponseEntity<String> createUser(@Valid @RequestBody CreateUserRequest newUser) {
         log.info("회원가입 요청 createUser: {}", newUser);
-        UsersCommandService.createUser(newUser);
+        usersCommandService.createUser(newUser);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /* 회원정보 수정 */
+    @PutMapping("/users/list/{userSeq}/edit")
+    public ResponseEntity<UpdateUserRequest> updateUser(
+            @PathVariable long userSeq,
+            @Valid @RequestBody UpdateUserRequest updateUserInfo) {
+        log.info("회원정보수정 updateUserInfo: {}", updateUserInfo);
+        // 테스트용 임시 userSeq 설정
+        long currentUserSeq = 13L; // 로그인한 유저의 userSeq 대신 하드코딩된 값 사용
+        // URL의 userSeq와 JSON의 userSeq가 다르면 400 Bad Request 반환
+        if (userSeq != updateUserInfo.getUserSeq()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(null);
+        }
+
+//        // 현재 로그인한 유저의 userSeq를 가져옴
+//        long currentUserSeq = CustomUserUtils.getCurrentUserSeq();
+//
+//        // 로그인한 유저의 userSeq와 요청의 userSeq가 다르면 403 Forbidden 응답
+//        if (currentUserSeq != userSeq) {
+//            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+//        }
+
+        UpdateUserRequest updateUser = usersCommandService.updateUserInfo(updateUserInfo);
+        return ResponseEntity.ok(updateUser);
+    }
+
+    /* 회원탈퇴 */
+    @DeleteMapping("/users/list/{userSeq}/delete")
+    public ResponseEntity<String> deleteUser(@PathVariable long userSeq, @RequestBody DeleteUserRequest deleteUserInfo) {
+        log.info("회원탈퇴 deleteUserInfo: {}", deleteUserInfo);
+        // 테스트용 임시 userSeq 설정
+        long currentUserSeq = 15L; // 로그인한 유저의 userSeq 대신 하드코딩된 값 사용
+        // URL의 userSeq와 JSON의 userSeq가 다르면 400 Bad Request 반환
+        if (userSeq != deleteUserInfo.getUserSeq()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(null);
+        }
+
+//        // 현재 로그인한 유저의 userSeq를 가져옴
+//        long currentUserSeq = CustomUserUtils.getCurrentUserSeq();
+//
+//        // 로그인한 유저의 userSeq와 요청의 userSeq가 다르면 403 Forbidden 응답
+//        if (currentUserSeq != userSeq) {
+//            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+//        }
+
+        // 서비스에서 탈퇴 처리
+        usersCommandService.deleteUser(deleteUserInfo);
+        return ResponseEntity.status(HttpStatus.OK).body("탈퇴가 성공적으로 처리되었습니다.");
     }
 
 

--- a/matzipback/src/main/java/com/matzip/matzipback/users/command/application/service/UsersCommandService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/command/application/service/UsersCommandService.java
@@ -6,6 +6,8 @@ import com.matzip.matzipback.users.command.domain.aggregate.Users;
 import com.matzip.matzipback.users.command.domain.repository.UsersDomainRepository;
 import com.matzip.matzipback.users.command.domain.service.UserActivityDomainService;
 import com.matzip.matzipback.users.command.dto.CreateUserRequest;
+import com.matzip.matzipback.users.command.dto.DeleteUserRequest;
+import com.matzip.matzipback.users.command.dto.UpdateUserRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -20,16 +22,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class UsersCommandService {
 
     private final UsersDomainRepository usersDomainRepository;
-    private final ModelMapper modelMapper;
+    private final ModelMapper modelMapper;  // dto와 entity 변환
   
     private final BCryptPasswordEncoder passwordEncoder; // 비밀번호 암호화
     private final EmailService emailService; // 이메일 인증 확인을 위한 서비스
     private final UUIDGenerator uuidGenerator; // 임의 닉네임 자동생성을 위한 유틸리티
-    private final UserActivityDomainService userActivityDomainService;
+    private final UserActivityDomainService userActivityDomainService; // 유저 활동도 서비스
 
-
+    /* 유저 생성 - 회원가입 */
     public void createUser(CreateUserRequest newUser) {
-        log.info("========create user========");
+        log.info("========회원가입 서비스 진입========");
 
 //        if (newUser.getUserPassword() == null || newUser.getUserPassword().isBlank()) {
 //            throw new IllegalArgumentException("비밀번호는 필수 입력 사항입니다.");
@@ -74,6 +76,7 @@ public class UsersCommandService {
         userActivityDomainService.saveUserActivity(UserActivity.create(users.getUserSeq()));
     }
 
+    /* 회원가입시 닉네임 임의자동생성을 위한 메소드 */
     private String createUniqueNickname(){
         log.info("========닉네임 중복체크 후 생성========");
         String nickname;
@@ -81,6 +84,71 @@ public class UsersCommandService {
             nickname = uuidGenerator.createRandomNickname();
         } while (usersDomainRepository.existsByUserNickname(nickname));
         return nickname;
+    }
+
+    /* 회원정보 수정 - 닉네임, 휴대폰, 비밀번호, 사업자 인증(추가) */
+    public UpdateUserRequest updateUserInfo(UpdateUserRequest updateUserInfo) {
+        log.info("========회원정보 수정 서비스 진입========");
+
+        // 전달 된 userSeq로 Users 엔티티 조회
+        Users user = usersDomainRepository.findById(updateUserInfo.getUserSeq())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        log.info("수정 요청 Nickname: {}", updateUserInfo.getUserNickname());
+        log.info("수정 전 Nickname: {}", user.getUserNickname());
+
+        // 닉네임 수정
+        if (updateUserInfo.getUserNickname() != null && !updateUserInfo.getUserNickname().trim().isEmpty()) {
+            if (updateUserInfo.getUserNickname().equals(user.getUserNickname())) {  // 수정 전/후 비교
+                throw new IllegalArgumentException("현재 닉네임과 동일한 닉네임으로는 변경할 수 없습니다.");
+            }
+            if (usersDomainRepository.existsByUserNickname(updateUserInfo.getUserNickname())) { // 클라이언트에게 전송받은 값이 이미 있는 닉네임인지(TRUE) 중복체크
+                throw new IllegalArgumentException("이미 사용 중인 닉네임입니다. 다른 닉네임을 선택해주세요.");
+            }
+            log.info("========닉네임 중복체크 후 수정완료 - UserNickname: {}========", updateUserInfo.getUserNickname());
+            user.updateNickname(updateUserInfo.getUserNickname());
+        }
+
+        // 비밀번호 수정 (비밀번호가 입력된 경우)
+        if (updateUserInfo.getUserPassword() != null && !updateUserInfo.getUserPassword().isBlank()) {
+            if (passwordEncoder.matches(updateUserInfo.getUserPassword(), user.getUserPassword())) {
+                throw new IllegalArgumentException("현재 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다.");
+            }
+            // 비밀번호 암호화
+            String encryptedPassword = passwordEncoder.encode(updateUserInfo.getUserPassword());
+            user.encryptPassword(encryptedPassword);
+            log.info("========비밀번호 수정 후 재암호화========");
+        }
+
+        // 휴대폰 번호 수정(추가 본인인증은 나중에 구현)
+        if (updateUserInfo.getUserPhone() != null) {
+            user.updatePhone(updateUserInfo.getUserPhone());
+            log.info("========휴대폰 번호 수정완료 - UserPhone: {}========", updateUserInfo.getUserPhone());
+        }
+
+        // 사업자 인증
+
+        // Users 엔티티 저장
+        Users updatedUser = usersDomainRepository.save(user);
+
+        // 업데이트된 정보를 DTO로 변환하여 반환
+        return modelMapper.map(updatedUser, UpdateUserRequest.class);
+    }
+
+    public void deleteUser(DeleteUserRequest deleteUserInfo) {
+        log.info("========회원탈퇴 서비스 진입========");
+
+        // 전달 된 userSeq로 Users 엔티티 조회
+        Users user = usersDomainRepository.findById(deleteUserInfo.getUserSeq())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(deleteUserInfo.getUserPassword(), user.getUserPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        usersDomainRepository.delete(user);
+
     }
 
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/users/command/domain/aggregate/Users.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/command/domain/aggregate/Users.java
@@ -1,12 +1,10 @@
 package com.matzip.matzipback.users.command.domain.aggregate;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -15,7 +13,7 @@ import java.time.LocalDateTime;
 @Table(name = "users")
 @NoArgsConstructor/*(access = AccessLevel.PROTECTED)*/
 @EntityListeners(AuditingEntityListener.class)  //@CreatedDate 사용위해
-@SQLDelete(sql = "UPDATE users SET user_status = 'delete', user_delete_date = NOW() WHERE user_seq = ?")
+@SQLDelete(sql = "UPDATE users SET user_status = 'inactive', user_delete_date = NOW() WHERE user_seq = ?")
 @Getter
 public class Users {
 
@@ -50,11 +48,26 @@ public class Users {
         if (businessVerifiedYn == null) businessVerifiedYn = "N"; // 사업자인증여부
     }
 
+    // 비밀번호 암호화
     public void encryptPassword(String password) {
         this.userPassword = password;
     }
 
+    // 닉네임 변경
     public void updateNickname(String nickname) {
-        this.userNickname = nickname;
+        if (nickname != null && !nickname.trim().isEmpty()) {
+            this.userNickname = nickname;
+        }
     }
+
+    // 휴대폰 번호 변경
+    public void updatePhone(String phoneNumber) {
+        this.userPhone = phoneNumber;
+    }
+
+    // 사업자 인증 상태 변경
+    public void updateBusinessStatus(boolean isVerified) {
+        this.businessVerifiedYn = isVerified ? "Y" : "N";
+    }
+
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/users/command/domain/repository/UsersDomainRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/command/domain/repository/UsersDomainRepository.java
@@ -13,4 +13,8 @@ public interface UsersDomainRepository {
     boolean existsByUserEmail(String userEmail); // 이메일 중복체크
 
     boolean existsByUserNickname(String userNickname);
+
+    Optional<Users> findById(Long userSeq);
+
+    void delete(Users user);
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/users/command/dto/DeleteUserRequest.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/command/dto/DeleteUserRequest.java
@@ -1,0 +1,14 @@
+package com.matzip.matzipback.users.command.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class DeleteUserRequest {
+
+    private long userSeq;
+    private String userPassword;
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/users/command/dto/UpdateUserRequest.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/command/dto/UpdateUserRequest.java
@@ -1,0 +1,23 @@
+package com.matzip.matzipback.users.command.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateUserRequest {
+
+    private long userSeq;
+    private String userPassword;
+//    @Pattern(regexp = "^[0-9]{10,11}$", message = "휴대폰 번호는 10자리 또는 11자리 숫자여야 합니다.")
+    private String userPhone;
+    @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+    @Size(min = 2, max = 16, message = "닉네임은 2자 이상, 16자 이하로 입력해주세요.")
+    private String userNickname;
+
+}


### PR DESCRIPTION
🌟개요
회원정보 수정, 탈퇴

🌐연결된 Issues
#79 
#80 

📋작업사항
회원정보 수정 : 닉네임, 비밀번호, 휴대폰번호 수정
회원 탈퇴 : 비활성화 상태로 변경(soft delete)

✏️작성한 이슈 외 작업사항
예외처리 핸들러에서 메소드 추가

✅체크리스트
---
- [x] PR 규칙을 준수하였는가?
- [x] 이슈번호를 작성하였는가?
- [x] 추가/수정 사항을 설명하였는가?
