### PR TITLE
feat: #74 회원정보 전체 조회 및 정렬 구현

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/report/query/dto/PenaltyDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/report/query/dto/PenaltyDTO.java
@@ -1,0 +1,19 @@
+package com.matzip.matzipback.report.query.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class PenaltyDTO {
+
+    private long penaltySeq;
+    private long userSeq;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String penaltyType;
+    private String penaltyReasonContent;
+
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
@@ -21,14 +21,15 @@ public class UsersQueryController {
 
     private final UsersInfoService usersInfoService;
 
-    @GetMapping("/auth/register")
-    public ResponseEntity<Map<String, String>> getSignUp() {
-        log.info("회원가입 화면으로 이동");
-        Map<String, String> response = new HashMap<>();
-        response.put("message", "회원가입 화면으로 이동");
-        response.put("url", "/register"); // 프론트엔드 회원가입 화면의 경로
-        return ResponseEntity.ok(response); // JSON 응답
-    }
+    // 로그인 검증 구현 시 되살릴 예정(프론트에서 직접 회원가입 창으로 이동가능하기때문)
+//    @GetMapping("/auth/register")
+//    public ResponseEntity<Map<String, String>> getSignUp() {
+//        log.info("회원가입 화면으로 이동");
+//        Map<String, String> response = new HashMap<>();
+//        response.put("message", "회원가입 화면으로 이동");
+//        response.put("url", "/register"); // 프론트엔드 회원가입 화면의 경로
+//        return ResponseEntity.ok(response); // JSON 응답
+//    }
 
 //    @GetMapping("/auth/login")
 //    public String getLogin(){

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
@@ -38,17 +38,41 @@ public class UsersQueryController {
 
     @GetMapping("/users/list")
     public ResponseEntity<AllUserInfoResponseDTO> getAllUserList(@RequestParam(value = "socialYn", required = false) String socialYn,
+                                                                 @RequestParam(value = "socialSite", required = false) String socialSite,
                                                                  @RequestParam(value = "businessVerifiedYn", required = false) String businessVerifiedYn,
                                                                  @RequestParam(value = "influencerYn", required = false) String influencerYn,
+                                                                 @RequestParam(value = "userStatus", required = false) String userStatus,
                                                                  @RequestParam(value = "orderBy", defaultValue = "regDateDesc") String orderBy,
                                                                  @RequestParam(value = "page", defaultValue = "1") Integer page,
                                                                  @RequestParam(value = "size", defaultValue = "10") Integer size) {
                                                                 //defaultValue : 기본값 설정, required = false : 파라미터 선택적(필수아님)
         log.info("GET /api/v1/users/list - 전체 회원 정보 조회 요청");
-        AllUserInfoResponseDTO users = usersInfoService.getAllUserList(socialYn, businessVerifiedYn, influencerYn, orderBy, page, size);
+        AllUserInfoResponseDTO users = usersInfoService.getAllUserList(socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, orderBy, page, size);
         log.info("전체 회원 정보 조회 완료. 현재 페이지: {}, 전체 페이지 수: {}, 총 유저 수: {}",
-
                 users.getCurrentPage(), users.getTotalPages(), users.getTotalUsers());
+
+        return ResponseEntity.ok(users);    // 결과 DTO를 ResponseEntity에 반환
+    }
+
+    @GetMapping("/users/search")
+    public ResponseEntity<AllUserInfoResponseDTO> getSearchUserList(
+            @RequestParam(value = "searchType", required = false) String searchType,
+            @RequestParam(value = "searchWord", required = false) String searchWord,
+            @RequestParam(value = "socialYn", required = false) String socialYn,
+            @RequestParam(value = "socialSite", required = false) String socialSite,
+            @RequestParam(value = "businessVerifiedYn", required = false) String businessVerifiedYn,
+            @RequestParam(value = "influencerYn", required = false) String influencerYn,
+            @RequestParam(value = "userStatus", required = false) String userStatus,
+            @RequestParam(value = "userAuth", required = false) String userAuth,
+            @RequestParam(value = "orderBy", defaultValue = "regDateDesc") String orderBy,
+            @RequestParam(value = "page", defaultValue = "1") Integer page,
+            @RequestParam(value = "size", defaultValue = "10") Integer size) {
+        //defaultValue : 기본값 설정, required = false : 파라미터 선택적(필수아님)
+        log.info("GET /api/v1/users/search - 회원 검색 조회 요청");
+        AllUserInfoResponseDTO users = usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite,
+                businessVerifiedYn, influencerYn, userStatus, userAuth, orderBy, page, size);
+        log.info("회원 검색 조회 완료. 현재 페이지: {}, 전체 페이지 수: {}, 검색결과 유저 수: {}, 검색타입 : {}, 검색어 : {}",
+                users.getCurrentPage(), users.getTotalPages(), users.getTotalUsers(), searchType, searchWord);
 
         return ResponseEntity.ok(users);    // 결과 DTO를 ResponseEntity에 반환
     }

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
@@ -1,10 +1,12 @@
 package com.matzip.matzipback.users.query.controller;
 
+import com.matzip.matzipback.users.command.domain.aggregate.Users;
 import com.matzip.matzipback.users.query.dto.userInfo.AllUserInfoResponseDTO;
 import com.matzip.matzipback.users.query.service.UsersInfoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -64,14 +66,24 @@ public class UsersQueryController {
             @RequestParam(value = "businessVerifiedYn", required = false) String businessVerifiedYn,
             @RequestParam(value = "influencerYn", required = false) String influencerYn,
             @RequestParam(value = "userStatus", required = false) String userStatus,
-            @RequestParam(value = "userAuth", required = false) String userAuth,
+//            @RequestParam(value = "userAuth", required = false) String userAuth,
             @RequestParam(value = "orderBy", defaultValue = "regDateDesc") String orderBy,
             @RequestParam(value = "page", defaultValue = "1") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size) {
+            @RequestParam(value = "size", defaultValue = "10") Integer size,
+            @AuthenticationPrincipal Users user // 로그인한 사용자의 정보를 가져옴
+    ) {
         //defaultValue : 기본값 설정, required = false : 파라미터 선택적(필수아님)
         log.info("GET /api/v1/users/search - 회원 검색 조회 요청");
-        AllUserInfoResponseDTO users = usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite,
-                businessVerifiedYn, influencerYn, userStatus, userAuth, orderBy, page, size);
+
+        String userAuth = user.getUserAuth();
+        AllUserInfoResponseDTO users;
+        if(userAuth.equals("user")) {   // 일반회원
+            users =  usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite, businessVerifiedYn, influencerYn, "actice", orderBy, page, size);
+        } else {    // 관리자
+            users =  usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite, businessVerifiedYn, influencerYn, null, orderBy, page, size);
+        }
+
+//        AllUserInfoResponseDTO users = usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, userAuth, orderBy, page, size);
         log.info("회원 검색 조회 완료. 현재 페이지: {}, 전체 페이지 수: {}, 검색결과 유저 수: {}, 검색타입 : {}, 검색어 : {}",
                 users.getCurrentPage(), users.getTotalPages(), users.getTotalUsers(), searchType, searchWord);
 

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
@@ -1,5 +1,6 @@
 package com.matzip.matzipback.users.query.controller;
 
+import com.matzip.matzipback.common.util.CustomUserUtils;
 import com.matzip.matzipback.users.command.domain.aggregate.Users;
 import com.matzip.matzipback.users.query.dto.userInfo.AllUserInfoResponseDTO;
 import com.matzip.matzipback.users.query.service.UsersInfoService;
@@ -69,18 +70,18 @@ public class UsersQueryController {
 //            @RequestParam(value = "userAuth", required = false) String userAuth,
             @RequestParam(value = "orderBy", defaultValue = "regDateDesc") String orderBy,
             @RequestParam(value = "page", defaultValue = "1") Integer page,
-            @RequestParam(value = "size", defaultValue = "10") Integer size,
-            @AuthenticationPrincipal Users user // 로그인한 사용자의 정보를 가져옴
+            @RequestParam(value = "size", defaultValue = "10") Integer size
+//            @AuthenticationPrincipal Users user // 로그인한 사용자의 정보를 가져옴
     ) {
         //defaultValue : 기본값 설정, required = false : 파라미터 선택적(필수아님)
         log.info("GET /api/v1/users/search - 회원 검색 조회 요청");
-
-        String userAuth = user.getUserAuth();
+        
+        String userAuth = CustomUserUtils.getCurrentUserAuthorities().iterator().next().getAuthority();
         AllUserInfoResponseDTO users;
         if(userAuth.equals("user")) {   // 일반회원
-            users =  usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite, businessVerifiedYn, influencerYn, "actice", orderBy, page, size);
+            users =  usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite, businessVerifiedYn, influencerYn, "actice", userAuth, orderBy, page, size);
         } else {    // 관리자
-            users =  usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite, businessVerifiedYn, influencerYn, null, orderBy, page, size);
+            users =  usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite, businessVerifiedYn, influencerYn, null, userAuth, orderBy, page, size);
         }
 
 //        AllUserInfoResponseDTO users = usersInfoService.getSearchUserList(searchType, searchWord, socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, userAuth, orderBy, page, size);

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/controller/UsersQueryController.java
@@ -1,23 +1,56 @@
 package com.matzip.matzipback.users.query.controller;
 
+import com.matzip.matzipback.users.query.dto.userInfo.AllUserInfoResponseDTO;
+import com.matzip.matzipback.users.query.service.UsersInfoService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
+@Slf4j
 public class UsersQueryController {
 
+    private final UsersInfoService usersInfoService;
+
     @GetMapping("/auth/register")
-    public String getSignUp(){
-        return "";
+    public ResponseEntity<Map<String, String>> getSignUp() {
+        log.info("회원가입 화면으로 이동");
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "회원가입 화면으로 이동");
+        response.put("url", "/register"); // 프론트엔드 회원가입 화면의 경로
+        return ResponseEntity.ok(response); // JSON 응답
     }
 
-    @GetMapping("/auth/login")
-    public String getLogin(){
-        return "";
+//    @GetMapping("/auth/login")
+//    public String getLogin(){
+//
+//        return "";
+//    }
+
+    @GetMapping("/users/list")
+    public ResponseEntity<AllUserInfoResponseDTO> getAllUserList(@RequestParam(value = "socialYn", required = false) String socialYn,
+                                                                 @RequestParam(value = "businessVerifiedYn", required = false) String businessVerifiedYn,
+                                                                 @RequestParam(value = "influencerYn", required = false) String influencerYn,
+                                                                 @RequestParam(value = "orderBy", defaultValue = "regDateDesc") String orderBy,
+                                                                 @RequestParam(value = "page", defaultValue = "1") Integer page,
+                                                                 @RequestParam(value = "size", defaultValue = "10") Integer size) {
+                                                                //defaultValue : 기본값 설정, required = false : 파라미터 선택적(필수아님)
+        log.info("GET /api/v1/users/list - 전체 회원 정보 조회 요청");
+        AllUserInfoResponseDTO users = usersInfoService.getAllUserList(socialYn, businessVerifiedYn, influencerYn, orderBy, page, size);
+        log.info("전체 회원 정보 조회 완료. 현재 페이지: {}, 전체 페이지 수: {}, 총 유저 수: {}",
+
+                users.getCurrentPage(), users.getTotalPages(), users.getTotalUsers());
+
+        return ResponseEntity.ok(users);    // 결과 DTO를 ResponseEntity에 반환
     }
 
 

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/AllUserInfoResponseDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/AllUserInfoResponseDTO.java
@@ -1,0 +1,21 @@
+package com.matzip.matzipback.users.query.dto.userInfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+//@Setter
+//@AllArgsConstructor
+@Builder
+public class AllUserInfoResponseDTO {
+
+    private List<UserInfoDTO> userLists;
+    private int currentPage;            // 현재 페이지
+    private int totalPages;             // 전체 페이지 수
+    private long totalUsers;            // 총 회원 수
+
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/BusinessLicenseDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/BusinessLicenseDTO.java
@@ -1,0 +1,20 @@
+package com.matzip.matzipback.users.query.dto.userInfo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class BusinessLicenseDTO {
+
+    private long businessSeq;
+    private long userSeq;
+    private String businessName;
+    private String businessNumber;
+    private String businessAddress;
+    private LocalDateTime verificationDate;
+    private int businessStatus;
+
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/UserActivityInfoDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/UserActivityInfoDTO.java
@@ -1,0 +1,16 @@
+package com.matzip.matzipback.users.query.dto.userInfo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserActivityInfoDTO {
+
+    private long userSeq;
+    private long activeLevelSeq;
+    private String activeLevelName; // 등급 이름
+    private long activityPoint; // 활동 포인트
+    private int activeLevelStandard; // 등급 기준
+    private String influencerYn; // 인기회원 여부
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/UserInfoDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/UserInfoDTO.java
@@ -1,0 +1,27 @@
+package com.matzip.matzipback.users.query.dto.userInfo;
+
+import com.matzip.matzipback.report.query.dto.PenaltyDTO;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class UserInfoDTO {
+
+    private long userSeq;
+    private String userEmail;
+    private String userNickname;
+    private String socialYn;
+    private String socialSite;
+    private String businessVerifiedYn;
+    private String penaltyYn;
+    private String userStatus;
+    private LocalDateTime userRegDate;
+    private LocalDateTime userDeleteDate;
+
+    private PenaltyDTO penalty; // 패널티 정보
+    private UserActivityInfoDTO activityInfo;  // 활동도
+
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/UserInfoDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/dto/userInfo/UserInfoDTO.java
@@ -18,6 +18,7 @@ public class UserInfoDTO {
     private String businessVerifiedYn;
     private String penaltyYn;
     private String userStatus;
+    private String userAuth;
     private LocalDateTime userRegDate;
     private LocalDateTime userDeleteDate;
 

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersInfoMapper.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersInfoMapper.java
@@ -31,7 +31,7 @@ public interface UsersInfoMapper {
                                      @Param("businessVerifiedYn") String businessVerifiedYn,
                                      @Param("influencerYn") String influencerYn,
                                      @Param("userStatus") String userStatus,
-//                                     @Param("userAuth") String userAuth,
+                                     @Param("userAuth") String userAuth,
                                      @Param("orderBy") String orderBy,
                                      @Param("size") Integer size,
                                      @Param("offset") int offset);
@@ -42,6 +42,6 @@ public interface UsersInfoMapper {
                             @Param("socialSite") String socialSite,
                             @Param("businessVerifiedYn") String businessVerifiedYn,
                             @Param("influencerYn") String influencerYn,
-                            @Param("userStatus") String userStatus/*,
-                            @Param("userAuth") String userAuth*/);
+                            @Param("userStatus") String userStatus,
+                            @Param("userAuth") String userAuth);
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersInfoMapper.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersInfoMapper.java
@@ -31,7 +31,7 @@ public interface UsersInfoMapper {
                                      @Param("businessVerifiedYn") String businessVerifiedYn,
                                      @Param("influencerYn") String influencerYn,
                                      @Param("userStatus") String userStatus,
-                                     @Param("userAuth") String userAuth,
+//                                     @Param("userAuth") String userAuth,
                                      @Param("orderBy") String orderBy,
                                      @Param("size") Integer size,
                                      @Param("offset") int offset);
@@ -42,6 +42,6 @@ public interface UsersInfoMapper {
                             @Param("socialSite") String socialSite,
                             @Param("businessVerifiedYn") String businessVerifiedYn,
                             @Param("influencerYn") String influencerYn,
-                            @Param("userStatus") String userStatus,
-                            @Param("userAuth") String userAuth);
+                            @Param("userStatus") String userStatus/*,
+                            @Param("userAuth") String userAuth*/);
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersInfoMapper.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersInfoMapper.java
@@ -10,14 +10,38 @@ import java.util.List;
 public interface UsersInfoMapper {
 
     List<UserInfoDTO> getAllUserInfo(@Param("socialYn") String socialYn,    // 명시적 매핑위해 @Param 으로 작성
+                                     @Param("socialSite") String socialSite,
                                      @Param("businessVerifiedYn") String businessVerifiedYn,
                                      @Param("influencerYn") String influencerYn,
+                                     @Param("userStatus") String userStatus,
                                      @Param("orderBy") String orderBy,
                                      @Param("size") Integer size,
                                      @Param("offset") int offset);
 
-    long getTotalUserCount(@Param("socialYn") String socialYn,    // 명시적 매핑위해 @Param 으로 작성
+    Long getTotalUserCount(@Param("socialYn") String socialYn,    // 명시적 매핑위해 @Param 으로 작성
+                           @Param("socialSite") String socialSite,
                            @Param("businessVerifiedYn") String businessVerifiedYn,
-                           @Param("influencerYn") String influencerYn);
+                           @Param("influencerYn") String influencerYn,
+                           @Param("userStatus") String userStatus);
 
+    List<UserInfoDTO> searchUserInfo(@Param("searchType") String searchType,
+                                     @Param("searchWord") String searchWord,
+                                     @Param("socialYn") String socialYn,
+                                     @Param("socialSite") String socialSite,
+                                     @Param("businessVerifiedYn") String businessVerifiedYn,
+                                     @Param("influencerYn") String influencerYn,
+                                     @Param("userStatus") String userStatus,
+                                     @Param("userAuth") String userAuth,
+                                     @Param("orderBy") String orderBy,
+                                     @Param("size") Integer size,
+                                     @Param("offset") int offset);
+
+    Long getSearchUserCount(@Param("searchType") String searchType,
+                            @Param("searchWord") String searchWord,
+                            @Param("socialYn") String socialYn,
+                            @Param("socialSite") String socialSite,
+                            @Param("businessVerifiedYn") String businessVerifiedYn,
+                            @Param("influencerYn") String influencerYn,
+                            @Param("userStatus") String userStatus,
+                            @Param("userAuth") String userAuth);
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersInfoMapper.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/mapper/UsersInfoMapper.java
@@ -1,0 +1,23 @@
+package com.matzip.matzipback.users.query.mapper;
+
+import com.matzip.matzipback.users.query.dto.userInfo.UserInfoDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface UsersInfoMapper {
+
+    List<UserInfoDTO> getAllUserInfo(@Param("socialYn") String socialYn,    // 명시적 매핑위해 @Param 으로 작성
+                                     @Param("businessVerifiedYn") String businessVerifiedYn,
+                                     @Param("influencerYn") String influencerYn,
+                                     @Param("orderBy") String orderBy,
+                                     @Param("size") Integer size,
+                                     @Param("offset") int offset);
+
+    long getTotalUserCount(@Param("socialYn") String socialYn,    // 명시적 매핑위해 @Param 으로 작성
+                           @Param("businessVerifiedYn") String businessVerifiedYn,
+                           @Param("influencerYn") String influencerYn);
+
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersInfoService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersInfoService.java
@@ -49,7 +49,7 @@ public class UsersInfoService {
 
     public AllUserInfoResponseDTO getSearchUserList(String searchType, String searchWord,   // 검색조건
                                                     String socialYn, String socialSite, String businessVerifiedYn,
-                                                    String influencerYn, String userStatus,  String userAuth, String orderBy,   // 필터링 조건, 정렬
+                                                    String influencerYn, String userStatus,  /*String userAuth,*/ String orderBy,   // 필터링 조건, 정렬
                                                     Integer page, Integer size) {   // 페이징
         log.info("getSearchUserList() 호출 - 검색 조건: searchType={}, searchWord={}", searchType, searchWord);
 
@@ -58,14 +58,14 @@ public class UsersInfoService {
 
         // 유저 검색결과 수
         Long totalUsers = usersInfoMapper.getSearchUserCount(searchType, searchWord,
-                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, userAuth);
+                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus/*, userAuth*/);
 
         // 전체 페이지 수 계산
         int totalPages = (int) Math.ceil((double) totalUsers / size);
 
         // 페이징 된 유저 리스트 가져오기
         List<UserInfoDTO> userList = usersInfoMapper.searchUserInfo(searchType, searchWord,
-                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, userAuth, orderBy, size, offset);
+                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, /*userAuth,*/ orderBy, size, offset);
 
         log.info("getSearchUserList() 완료 - 페이지에 검색된 회원 수: {}, 총 회원 수 : {}", userList.size(), totalUsers);
 

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersInfoService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersInfoService.java
@@ -16,24 +16,25 @@ public class UsersInfoService {
 
     private final UsersInfoMapper usersInfoMapper;
 
-    public AllUserInfoResponseDTO getAllUserList(String socialYn, String businessVerifiedYn, String influencerYn,    // 필터링 조건
-                                                 String orderBy, Integer page, Integer size) {   // 정렬조건, 페이징
-        log.info("getAllUserList() 호출 - 필터링 조건: socialYn={}, businessVerifiedYn={}, influencerYn={}, orderBy={}",
-                socialYn, businessVerifiedYn, influencerYn, orderBy);
+    public AllUserInfoResponseDTO getAllUserList(String socialYn, String socialSite, String businessVerifiedYn,
+                                                 String influencerYn, String userStatus, String orderBy,   // 필터링 조건, 정렬
+                                                 Integer page, Integer size) {   // 페이징
+        log.info("getAllUserList() 호출 - 필터링 조건: socialYn={}, businessVerifiedYn={}, influencerYn={}, userStatus={}, orderBy={}",
+                socialYn, businessVerifiedYn, influencerYn, userStatus, orderBy);
 
         // 페이지 번호에 따른 offset 계산(offset : 데이터를 건너뛰는 개수)
         int offset = (page -1) * size;
 
         // 총 유저 수
-        long totalUsers = usersInfoMapper.getTotalUserCount(socialYn, businessVerifiedYn, influencerYn);
+        Long totalUsers = usersInfoMapper.getTotalUserCount(socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus);
 
         // 전체 페이지 수 계산
         int totalPages = (int) Math.ceil((double) totalUsers / size);
 
         // 페이징 된 유저 리스트 가져오기
-        List<UserInfoDTO> userList = usersInfoMapper.getAllUserInfo(socialYn, businessVerifiedYn, influencerYn, orderBy, size, offset);
+        List<UserInfoDTO> userList = usersInfoMapper.getAllUserInfo(socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, orderBy, size, offset);
 
-        log.info("getAllUsers() 완료 - 조회된 회원 수: {}", userList.size());
+        log.info("getAllUsers() 완료 - 페이지에 조회된 회원 수: {}, 총 회원 수 : {}", userList.size(), totalUsers);
 
 //        AllUserInfoResponseDTO allUserInfoResponseDTO = new AllUserInfoResponseDTO(userList, page, totalPages, totalUsers);
 //        return allUserInfoResponseDTO;
@@ -46,4 +47,35 @@ public class UsersInfoService {
     }
 
 
+    public AllUserInfoResponseDTO getSearchUserList(String searchType, String searchWord,   // 검색조건
+                                                    String socialYn, String socialSite, String businessVerifiedYn,
+                                                    String influencerYn, String userStatus,  String userAuth, String orderBy,   // 필터링 조건, 정렬
+                                                    Integer page, Integer size) {   // 페이징
+        log.info("getSearchUserList() 호출 - 검색 조건: searchType={}, searchWord={}", searchType, searchWord);
+
+        // 페이지 번호에 따른 offset 계산(offset : 데이터를 건너뛰는 개수)
+        int offset = (page -1) * size;
+
+        // 유저 검색결과 수
+        Long totalUsers = usersInfoMapper.getSearchUserCount(searchType, searchWord,
+                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, userAuth);
+
+        // 전체 페이지 수 계산
+        int totalPages = (int) Math.ceil((double) totalUsers / size);
+
+        // 페이징 된 유저 리스트 가져오기
+        List<UserInfoDTO> userList = usersInfoMapper.searchUserInfo(searchType, searchWord,
+                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, userAuth, orderBy, size, offset);
+
+        log.info("getSearchUserList() 완료 - 페이지에 검색된 회원 수: {}, 총 회원 수 : {}", userList.size(), totalUsers);
+
+//        AllUserInfoResponseDTO allUserInfoResponseDTO = new AllUserInfoResponseDTO(userList, page, totalPages, totalUsers);
+//        return allUserInfoResponseDTO;
+        return AllUserInfoResponseDTO.builder()
+                .userLists(userList)
+                .currentPage(page)
+                .totalPages(totalPages)
+                .totalUsers(totalUsers)
+                .build();
+    }
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersInfoService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersInfoService.java
@@ -1,0 +1,49 @@
+package com.matzip.matzipback.users.query.service;
+
+import com.matzip.matzipback.users.query.dto.userInfo.AllUserInfoResponseDTO;
+import com.matzip.matzipback.users.query.dto.userInfo.UserInfoDTO;
+import com.matzip.matzipback.users.query.mapper.UsersInfoMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UsersInfoService {
+
+    private final UsersInfoMapper usersInfoMapper;
+
+    public AllUserInfoResponseDTO getAllUserList(String socialYn, String businessVerifiedYn, String influencerYn,    // 필터링 조건
+                                                 String orderBy, Integer page, Integer size) {   // 정렬조건, 페이징
+        log.info("getAllUserList() 호출 - 필터링 조건: socialYn={}, businessVerifiedYn={}, influencerYn={}, orderBy={}",
+                socialYn, businessVerifiedYn, influencerYn, orderBy);
+
+        // 페이지 번호에 따른 offset 계산(offset : 데이터를 건너뛰는 개수)
+        int offset = (page -1) * size;
+
+        // 총 유저 수
+        long totalUsers = usersInfoMapper.getTotalUserCount(socialYn, businessVerifiedYn, influencerYn);
+
+        // 전체 페이지 수 계산
+        int totalPages = (int) Math.ceil((double) totalUsers / size);
+
+        // 페이징 된 유저 리스트 가져오기
+        List<UserInfoDTO> userList = usersInfoMapper.getAllUserInfo(socialYn, businessVerifiedYn, influencerYn, orderBy, size, offset);
+
+        log.info("getAllUsers() 완료 - 조회된 회원 수: {}", userList.size());
+
+//        AllUserInfoResponseDTO allUserInfoResponseDTO = new AllUserInfoResponseDTO(userList, page, totalPages, totalUsers);
+//        return allUserInfoResponseDTO;
+        return AllUserInfoResponseDTO.builder()
+                .userLists(userList)
+                .currentPage(page)
+                .totalPages(totalPages)
+                .totalUsers(totalUsers)
+                .build();
+    }
+
+
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersInfoService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/query/service/UsersInfoService.java
@@ -49,7 +49,7 @@ public class UsersInfoService {
 
     public AllUserInfoResponseDTO getSearchUserList(String searchType, String searchWord,   // 검색조건
                                                     String socialYn, String socialSite, String businessVerifiedYn,
-                                                    String influencerYn, String userStatus,  /*String userAuth,*/ String orderBy,   // 필터링 조건, 정렬
+                                                    String influencerYn, String userStatus,  String userAuth, String orderBy,   // 필터링 조건, 정렬
                                                     Integer page, Integer size) {   // 페이징
         log.info("getSearchUserList() 호출 - 검색 조건: searchType={}, searchWord={}", searchType, searchWord);
 
@@ -58,14 +58,14 @@ public class UsersInfoService {
 
         // 유저 검색결과 수
         Long totalUsers = usersInfoMapper.getSearchUserCount(searchType, searchWord,
-                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus/*, userAuth*/);
+                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, userAuth);
 
         // 전체 페이지 수 계산
         int totalPages = (int) Math.ceil((double) totalUsers / size);
 
         // 페이징 된 유저 리스트 가져오기
         List<UserInfoDTO> userList = usersInfoMapper.searchUserInfo(searchType, searchWord,
-                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, /*userAuth,*/ orderBy, size, offset);
+                socialYn, socialSite, businessVerifiedYn, influencerYn, userStatus, userAuth, orderBy, size, offset);
 
         log.info("getSearchUserList() 완료 - 페이지에 검색된 회원 수: {}, 총 회원 수 : {}", userList.size(), totalUsers);
 

--- a/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
+++ b/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.matzip.matzipback.users.query.mapper.UsersInfoMapper">
+    <resultMap id="UsersResultMap" type="com.matzip.matzipback.users.query.dto.userInfo.UserInfoDTO">
+        <id property="userSeq" column="user_seq"/>
+        <result property = "userEmail" column = "user_email"/>
+        <result property = "userNickname" column = "user_nickname"/>
+        <result property = "socialYn" column = "user_social_yn"/>
+        <result property = "socialSite" column = "user_social_site"/>
+        <result property = "businessVerifiedYn" column = "business_verified_yn"/>
+        <result property = "penaltyYn" column = "penalty_yn"/>
+        <result property = "userStatus" column = "user_status"/>
+        <result property = "userRegDate" column = "user_reg_date"/>
+        <result property = "userDeleteDate" column = "user_delete_date"/>
+
+        <!-- 패널티 정보 -->
+        <association property="penalty" resultMap="PenaltyResultMap"/>
+        <!-- 회원 활동 정보 -->
+        <association property="activityInfo" resultMap="ActivityResultMap"/>
+    </resultMap>
+
+    <resultMap id="ActivityResultMap" type="com.matzip.matzipback.users.query.dto.userInfo.UserActivityInfoDTO">
+        <id property="userSeq" column="activity_user_seq"/>
+        <result property="activeLevelSeq" column="active_level_seq"/>
+        <result property="activeLevelName" column="active_level_name"/>
+        <result property="activityPoint" column="activity_point"/>
+        <result property="activeLevelStandard" column="active_level_standard"/>
+        <result property="influencerYn" column="influencer_yn"/>
+    </resultMap>
+
+    <resultMap id="PenaltyResultMap" type="com.matzip.matzipback.report.query.dto.PenaltyDTO">
+        <id property="penaltySeq" column="penalty_seq"/>
+        <result property="userSeq" column="penalty_user_seq"/>
+        <result property="startDate" column="penalty_start_date"/>
+        <result property="endDate" column="penalty_end_date"/>
+        <result property="penaltyType" column="penalty_type"/>
+        <result property="penaltyReasonContent" column="penalty_reason_content"/>
+    </resultMap>
+
+<!--    <resultMap id="ResultMap" type="com.matzip.matzipback.users.query.dto.userInfo.BusinessLicenseDTO">-->
+<!--        <id property="businessSeq" column="business_seq"/>-->
+<!--        <result property="userSeq" column="user_seq"/>-->
+<!--        <result property="businessName" column="business_name"/>-->
+<!--        <result property="businessNumber" column="business_number"/>-->
+<!--        <result property="businessAddress" column="business_address"/>-->
+<!--        <result property="verificationDate" column="business_verification_date"/>-->
+<!--        <result property="businessStatus" column="business_verification_status"/>-->
+<!--    </resultMap>-->
+
+    <select id="getAllUserInfo" resultMap="UsersResultMap">
+        SELECT u.user_seq
+             , u.user_email
+             , u.user_nickname
+             , u.user_social_yn
+             , u.user_social_site
+             , u.business_verified_yn
+             , CASE
+            <![CDATA[
+               WHEN u.penalty_yn = 'Y'
+                AND p.penalty_start_date <= NOW()
+                AND p.penalty_end_date >= NOW()
+               THEN 'Y'
+               ELSE 'N'
+                END AS penalty_yn
+             , CASE
+               WHEN u.penalty_yn = 'Y'
+                AND p.penalty_start_date <= NOW()
+                AND p.penalty_end_date >= NOW()
+               THEN p.penalty_start_date
+               ELSE NULL
+                END AS penalty_start_date
+             , CASE
+               WHEN u.penalty_yn = 'Y'
+                AND p.penalty_start_date <= NOW()
+                AND p.penalty_end_date >= NOW()
+               THEN p.penalty_end_date
+               ELSE NULL
+             ]]>
+                END AS penalty_end_date
+             , u.user_status
+             , u.user_reg_date
+             , u.user_delete_date
+             , ua.activity_point
+             , al.active_level_name
+             , al.active_level_standard
+             , ua.influencer_yn
+        FROM users u
+        LEFT JOIN user_activity ua ON u.user_seq = ua.activity_user_seq
+        LEFT JOIN active_level al ON ua.active_level_seq = al.active_level_seq
+        LEFT JOIN penalty p ON u.user_seq = p.penalty_user_seq
+        <where>
+            <!-- 관리자 계정 제외 -->
+            u.user_auth = 'user'
+            <!-- 소셜회원 여부 필터링 -->
+            <if test="socialYn != null and socialYn != ''">
+                u.user_social_yn = #{socialYn}
+                <!-- 소셜회원인 경우에는 socialSite 보이게 조건 추가 -->
+                <if test="socialSite != null and socialSite != ''">
+                    AND u.user_social_site = #{socialSite}
+                </if>
+            </if>
+            <!-- 사업자 인증여부 필터링 -->
+            <if test="businessVerifiedYn != null and businessVerifiedYn != ''">
+                AND u.business_verified_yn = #{businessVerifiedYn}
+            </if>
+            <!-- 인기회원 여부 필터링 -->
+            <if test="influencerYn != null and influencerYn != ''">
+                AND u.influencer_yn = #{influencerYn}
+            </if>
+        </where>
+        ORDER BY
+        <choose>
+            <when test="orderBy == 'regDateDesc'">
+                u.user_reg_date DESC
+            </when>
+            <when test="orderBy == 'regDateAsc'">
+                u.user_reg_date ASC
+            </when>
+            <when test="orderBy == 'pointDesc'">
+                ua.activity_point DESC
+            </when>
+            <when test="orderBy == 'pointAsc'">
+                ua.activity_point ASC
+            </when>
+            <otherwise>
+                u.user_reg_date DESC <!-- 기본 정렬: 최신순 -->
+            </otherwise>
+        </choose>
+        LIMIT #{size} OFFSET #{offset}  <!-- 페이징을 위한 코드 -->
+    </select>
+
+    <select id="getTotalUserCount" resultType="long">
+        SELECT COUNT(*)
+        FROM users u
+        LEFT JOIN user_activity ua ON u.user_seq = ua.activity_user_seq
+        LEFT JOIN active_level al ON ua.active_level_seq = al.active_level_seq
+        LEFT JOIN penalty p ON u.user_seq = p.penalty_user_seq
+        <where>
+            u.user_auth = 'user'
+            <if test="socialYn != null and socialYn != ''">
+                u.user_social_yn = #{socialYn}
+                <if test="socialSite != null and socialSite != ''">
+                    AND u.user_social_site = #{socialSite}
+                </if>
+            </if>
+            <if test="businessVerifiedYn != null and businessVerifiedYn != ''">
+                AND u.business_verified_yn = #{businessVerifiedYn}
+            </if>
+            <if test="influencerYn != null and influencerYn != ''">
+                AND u.influencer_yn = #{influencerYn}
+            </if>
+        </where>
+    </select>
+
+</mapper>

--- a/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
+++ b/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
@@ -96,6 +96,10 @@
         <where>
             <!-- 관리자 계정 제외 -->
             u.user_auth = 'user'
+            <if test="userStatus != null and userStatus != ''">
+                And u.user_status = #{userStatus}
+            </if>
+
             <!-- 소셜회원 여부 필터링 -->
             <if test="socialYn != null and socialYn != ''">
                 u.user_social_yn = #{socialYn}
@@ -157,6 +161,10 @@
         LEFT JOIN penalty p ON u.user_seq = p.penalty_user_seq
         <where>
             u.user_auth = 'user'
+            <if test="userStatus != null and userStatus != ''">
+                And u.user_status = #{userStatus}
+            </if>
+
             <if test="socialYn != null and socialYn != ''">
                 u.user_social_yn = #{socialYn}
                 <if test="socialYn == 'Y' and socialSite != null and socialSite != ''">
@@ -221,6 +229,9 @@
         <where>
             <!-- 관리자 계정 제외 -->
             u.user_auth = 'user'
+            <if test="userStatus != null and userStatus != ''">
+                And u.user_status = #{userStatus}
+            </if>
 
             <!-- 검색 조건 추가 -->
             <if test="searchWord != null and searchWord != ''">
@@ -315,6 +326,9 @@
         <where>
             <!-- 관리자 계정 제외 -->
             u.user_auth = 'user'
+            <if test="userStatus != null and userStatus != ''">
+                And u.user_status = #{userStatus}
+            </if>
 
             <!-- 검색 조건 추가 -->
             <if test="searchWord != null and searchWord != ''">

--- a/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
+++ b/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
@@ -107,7 +107,7 @@
             </if>
             <!-- 인기회원 여부 필터링 -->
             <if test="influencerYn != null and influencerYn != ''">
-                AND u.influencer_yn = #{influencerYn}
+                AND ua.influencer_yn = #{influencerYn}
             </if>
         </where>
         ORDER BY
@@ -161,7 +161,7 @@
                 AND u.business_verified_yn = #{businessVerifiedYn}
             </if>
             <if test="influencerYn != null and influencerYn != ''">
-                AND u.influencer_yn = #{influencerYn}
+                AND ua.influencer_yn = #{influencerYn}
             </if>
         </where>
     </select>

--- a/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
+++ b/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
@@ -113,19 +113,31 @@
         ORDER BY
         <choose>
             <when test="orderBy == 'regDateDesc'">
-                u.user_reg_date DESC
+                u.user_reg_date DESC, ua.activity_point DESC  <!-- 가입일 먼저 내림차순, 포인트 내림차순 -->
             </when>
             <when test="orderBy == 'regDateAsc'">
-                u.user_reg_date ASC
+                u.user_reg_date ASC, ua.activity_point DESC  <!-- 가입일 먼저 오름차순, 포인트 내림차순 -->
             </when>
             <when test="orderBy == 'pointDesc'">
-                ua.activity_point DESC
+                ua.activity_point DESC, u.user_reg_date DESC  <!-- 포인트 먼저 내림차순, 가입일 내림차순 -->
             </when>
             <when test="orderBy == 'pointAsc'">
-                ua.activity_point ASC
+                ua.activity_point ASC, u.user_reg_date DESC  <!-- 포인트 먼저 오름차순, 가입일 내림차순 -->
+            </when>
+            <when test="orderBy == 'regDateAscPointAsc'">
+                u.user_reg_date ASC, ua.activity_point Asc  <!-- 가입일 오름차순, 포인트 오름차순 -->
+            </when>
+            <when test="orderBy == 'regDateDescPointAsc'">
+                u.user_reg_date DESC, ua.activity_point Asc  <!-- 가입일 내림차순, 포인트 오름차순 -->
+            </when>
+            <when test="orderBy == 'pointAscRegDateAsc'">
+                ua.activity_point ASC, u.user_reg_date Asc   <!-- 포인트 오름차순, 가입일 오름차순 -->
+            </when>
+            <when test="orderBy == 'pointDescRegDateAsc'">
+                ua.activity_point Desc, u.user_reg_date Asc   <!-- 포인트 내림차순, 가입일 오름차순 -->
             </when>
             <otherwise>
-                u.user_reg_date DESC <!-- 기본 정렬: 최신순 -->
+                u.user_reg_date DESC, ua.activity_point DESC  <!-- 기본값: 가입일 내림차순, 포인트 내림차순 -->
             </otherwise>
         </choose>
         LIMIT #{size} OFFSET #{offset}  <!-- 페이징을 위한 코드 -->

--- a/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
+++ b/matzipback/src/main/resources/mappers/usersMappers/UserListMapper.xml
@@ -12,6 +12,7 @@
         <result property = "businessVerifiedYn" column = "business_verified_yn"/>
         <result property = "penaltyYn" column = "penalty_yn"/>
         <result property = "userStatus" column = "user_status"/>
+        <result property = "userAuth" column = "user_auth"/>
         <result property = "userRegDate" column = "user_reg_date"/>
         <result property = "userDeleteDate" column = "user_delete_date"/>
 
@@ -49,6 +50,7 @@
 <!--        <result property="businessStatus" column="business_verification_status"/>-->
 <!--    </resultMap>-->
 
+    <!-- 회원 전체조회 : 관리자 -->
     <select id="getAllUserInfo" resultMap="UsersResultMap">
         SELECT u.user_seq
              , u.user_email
@@ -80,6 +82,7 @@
              ]]>
                 END AS penalty_end_date
              , u.user_status
+             , u.user_auth
              , u.user_reg_date
              , u.user_delete_date
              , ua.activity_point
@@ -97,7 +100,7 @@
             <if test="socialYn != null and socialYn != ''">
                 u.user_social_yn = #{socialYn}
                 <!-- 소셜회원인 경우에는 socialSite 보이게 조건 추가 -->
-                <if test="socialSite != null and socialSite != ''">
+                <if test="socialYn == 'Y' and socialSite != null and socialSite != ''">
                     AND u.user_social_site = #{socialSite}
                 </if>
             </if>
@@ -109,40 +112,43 @@
             <if test="influencerYn != null and influencerYn != ''">
                 AND ua.influencer_yn = #{influencerYn}
             </if>
+            <!-- 가입상태 필터링 -->
+            <if test="userStatus != null and userStatus != ''">
+                AND u.user_status = #{userStatus}
+            </if>
         </where>
         ORDER BY
+        ua.influencer_yn DESC  <!-- 기본 정렬: 인기 회원 여부 순 Y -> N -->
+
+        <!-- 추가 정렬 조건 -->
         <choose>
+            <!-- 등급 순 정렬 -->
+            <when test="orderBy == 'gradeDESC'">
+                , ua.activity_point DESC
+            </when>
+            <when test="orderBy == 'gradeASC'">
+                , ua.activity_point ASC
+            </when>
+
+            <!-- 닉네임 순 정렬 -->
+            <when test="orderBy == 'nicknameASC'">
+                , u.user_nickname ASC
+            </when>
+            <when test="orderBy == 'nicknameDESC'">
+                , u.user_nickname DESC
+            </when>
+
             <when test="orderBy == 'regDateDesc'">
-                u.user_reg_date DESC, ua.activity_point DESC  <!-- 가입일 먼저 내림차순, 포인트 내림차순 -->
+                , u.user_reg_date DESC
             </when>
             <when test="orderBy == 'regDateAsc'">
-                u.user_reg_date ASC, ua.activity_point DESC  <!-- 가입일 먼저 오름차순, 포인트 내림차순 -->
+                , u.user_reg_date ASC
             </when>
-            <when test="orderBy == 'pointDesc'">
-                ua.activity_point DESC, u.user_reg_date DESC  <!-- 포인트 먼저 내림차순, 가입일 내림차순 -->
-            </when>
-            <when test="orderBy == 'pointAsc'">
-                ua.activity_point ASC, u.user_reg_date DESC  <!-- 포인트 먼저 오름차순, 가입일 내림차순 -->
-            </when>
-            <when test="orderBy == 'regDateAscPointAsc'">
-                u.user_reg_date ASC, ua.activity_point Asc  <!-- 가입일 오름차순, 포인트 오름차순 -->
-            </when>
-            <when test="orderBy == 'regDateDescPointAsc'">
-                u.user_reg_date DESC, ua.activity_point Asc  <!-- 가입일 내림차순, 포인트 오름차순 -->
-            </when>
-            <when test="orderBy == 'pointAscRegDateAsc'">
-                ua.activity_point ASC, u.user_reg_date Asc   <!-- 포인트 오름차순, 가입일 오름차순 -->
-            </when>
-            <when test="orderBy == 'pointDescRegDateAsc'">
-                ua.activity_point Desc, u.user_reg_date Asc   <!-- 포인트 내림차순, 가입일 오름차순 -->
-            </when>
-            <otherwise>
-                u.user_reg_date DESC, ua.activity_point DESC  <!-- 기본값: 가입일 내림차순, 포인트 내림차순 -->
-            </otherwise>
         </choose>
         LIMIT #{size} OFFSET #{offset}  <!-- 페이징을 위한 코드 -->
     </select>
 
+    <!-- 회원 전체조회 총 회원수 -->
     <select id="getTotalUserCount" resultType="long">
         SELECT COUNT(*)
         FROM users u
@@ -153,7 +159,7 @@
             u.user_auth = 'user'
             <if test="socialYn != null and socialYn != ''">
                 u.user_social_yn = #{socialYn}
-                <if test="socialSite != null and socialSite != ''">
+                <if test="socialYn == 'Y' and socialSite != null and socialSite != ''">
                     AND u.user_social_site = #{socialSite}
                 </if>
             </if>
@@ -162,6 +168,203 @@
             </if>
             <if test="influencerYn != null and influencerYn != ''">
                 AND ua.influencer_yn = #{influencerYn}
+            </if>
+            <if test="userStatus != null and userStatus != ''">
+                AND u.user_status = #{userStatus}
+            </if>
+        </where>
+    </select>
+
+    <!-- 회원 검색 : 관리자, 회원 / 화면에서 보여줄 정보를 나눌 것임 -->
+    <select id="searchUserInfo" resultMap="UsersResultMap">
+        SELECT u.user_seq
+             , u.user_email
+             , u.user_nickname
+             , u.user_social_yn
+             , u.user_social_site
+             , u.business_verified_yn
+             , CASE
+            <![CDATA[
+               WHEN u.penalty_yn = 'Y'
+                AND p.penalty_start_date <= NOW()
+                AND p.penalty_end_date >= NOW()
+               THEN 'Y'
+               ELSE 'N'
+                END AS penalty_yn
+             , CASE
+               WHEN u.penalty_yn = 'Y'
+                AND p.penalty_start_date <= NOW()
+                AND p.penalty_end_date >= NOW()
+               THEN p.penalty_start_date
+               ELSE NULL
+                END AS penalty_start_date
+             , CASE
+               WHEN u.penalty_yn = 'Y'
+                AND p.penalty_start_date <= NOW()
+                AND p.penalty_end_date >= NOW()
+               THEN p.penalty_end_date
+               ELSE NULL
+             ]]>
+                END AS penalty_end_date
+            , u.user_status
+            , u.user_auth
+            , u.user_reg_date
+            , u.user_delete_date
+            , ua.activity_point
+            , al.active_level_name
+            , al.active_level_standard
+            , ua.influencer_yn
+        FROM users u
+        LEFT JOIN user_activity ua ON u.user_seq = ua.activity_user_seq
+        LEFT JOIN active_level al ON ua.active_level_seq = al.active_level_seq
+        LEFT JOIN penalty p ON u.user_seq = p.penalty_user_seq
+        <where>
+            <!-- 관리자 계정 제외 -->
+            u.user_auth = 'user'
+
+            <!-- 검색 조건 추가 -->
+            <if test="searchWord != null and searchWord != ''">
+                <choose>
+                    <!-- 관리자는 이메일 또는 닉네임 검색 가능 -->
+                    <when test="userAuth == 'admin'">
+                        <choose>
+                            <!-- 이메일로 검색 -->
+                            <when test="searchType == 'email'">
+                                AND u.user_email LIKE CONCAT('%', #{searchWord}, '%')
+                            </when>
+                            <!-- 닉네임으로 검색 -->
+                            <when test="searchType == 'nickname'">
+                                AND u.user_nickname LIKE CONCAT('%', #{searchWord}, '%')
+                            </when>
+                        </choose>
+                    </when>
+
+                    <!-- 일반 사용자는 닉네임으로만 검색 가능 -->
+                    <when test="userAuth == 'user'">
+                        AND u.user_nickname LIKE CONCAT('%', #{searchWord}, '%')
+                    </when>
+                </choose>
+            </if>
+
+            <if test="userAuth == 'user'">
+                AND u.user_status = 'active'  <!-- 일반 사용자일 때는 탈퇴 회원 제외 -->
+            </if>
+            <if test="userAuth == 'admin'">
+                <!-- 관리자일 때만 탈퇴 회원도 조회, 필터링은 관리자만 가능 -->
+                <!-- 소셜회원 여부 필터링 -->
+                <if test="socialYn == 'Y' and socialYn != null and socialYn != ''">
+                    u.user_social_yn = #{socialYn}
+                    <!-- 소셜회원인 경우에는 socialSite 보이게 조건 추가 -->
+                    <if test="socialSite != null and socialSite != ''">
+                        AND u.user_social_site = #{socialSite}
+                    </if>
+                </if>
+                <!-- 사업자 인증여부 필터링 -->
+                <if test="businessVerifiedYn != null and businessVerifiedYn != ''">
+                    AND u.business_verified_yn = #{businessVerifiedYn}
+                </if>
+                <!-- 인기회원 여부 필터링 -->
+                <if test="influencerYn != null and influencerYn != ''">
+                    AND ua.influencer_yn = #{influencerYn}
+                </if>
+                <!-- 가입상태 필터링 -->
+                <if test="userStatus != null and userStatus != ''">
+                    AND u.user_status = #{userStatus}
+                </if>
+            </if>
+        </where>
+        ORDER BY
+        ua.influencer_yn DESC  <!-- 기본 정렬: 인기 회원 여부 순 Y -> N -->
+
+        <!-- 추가 정렬 조건 -->
+        <choose>
+            <!-- 등급 순 정렬 -->
+            <when test="orderBy == 'gradeDESC'">
+                , ua.activity_point DESC
+            </when>
+            <when test="orderBy == 'gradeASC'">
+                , ua.activity_point ASC
+            </when>
+
+            <!-- 닉네임 순 정렬 -->
+            <when test="orderBy == 'nicknameASC'">
+                , u.user_nickname ASC
+            </when>
+            <when test="orderBy == 'nicknameDESC'">
+                , u.user_nickname DESC
+            </when>
+
+            <!-- 관리자만 가입일 순 정렬 가능 -->
+            <when test="userAuth == 'admin' and orderBy == 'regDateDesc'">
+                , u.user_reg_date DESC
+            </when>
+            <when test="userAuth == 'admin' and orderBy == 'regDateAsc'">
+                , u.user_reg_date ASC
+            </when>
+        </choose>
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+    <!-- 회원 검색 결과 회원 수 -->
+    <select id="getSearchUserCount" resultType="long">
+        SELECT COUNT(*)
+        FROM users u
+        LEFT JOIN user_activity ua ON u.user_seq = ua.activity_user_seq
+        LEFT JOIN active_level al ON ua.active_level_seq = al.active_level_seq
+        LEFT JOIN penalty p ON u.user_seq = p.penalty_user_seq
+        <where>
+            <!-- 관리자 계정 제외 -->
+            u.user_auth = 'user'
+
+            <!-- 검색 조건 추가 -->
+            <if test="searchWord != null and searchWord != ''">
+                <choose>
+                    <!-- 관리자는 이메일 또는 닉네임 검색 가능 -->
+                    <when test="userAuth == 'admin'">
+                        <choose>
+                            <!-- 이메일로 검색 -->
+                            <when test="searchType == 'email'">
+                                AND u.user_email LIKE CONCAT('%', #{searchWord}, '%')
+                            </when>
+                            <!-- 닉네임으로 검색 -->
+                            <when test="searchType == 'nickname'">
+                                AND u.user_nickname LIKE CONCAT('%', #{searchWord}, '%')
+                            </when>
+                        </choose>
+                    </when>
+
+                    <!-- 일반 사용자는 닉네임으로만 검색 가능 -->
+                    <when test="userAuth == 'user'">
+                        AND u.user_nickname LIKE CONCAT('%', #{searchWord}, '%')
+                    </when>
+                </choose>
+            </if>
+
+            <if test="userAuth == 'user'">
+                AND u.user_status = 'active'  <!-- 일반 사용자일 때는 탈퇴 회원 제외 -->
+            </if>
+            <if test="userAuth == 'admin'">
+                <!-- 관리자일 때만 탈퇴 회원도 조회, 필터링은 관리자만 가능 -->
+                <!-- 소셜회원 여부 필터링 -->
+                <if test="socialYn == 'Y' and socialYn != null and socialYn != ''">
+                    u.user_social_yn = #{socialYn}
+                    <!-- 소셜회원인 경우에는 socialSite 보이게 조건 추가 -->
+                    <if test="socialSite != null and socialSite != ''">
+                        AND u.user_social_site = #{socialSite}
+                    </if>
+                </if>
+                <!-- 사업자 인증여부 필터링 -->
+                <if test="businessVerifiedYn != null and businessVerifiedYn != ''">
+                    AND u.business_verified_yn = #{businessVerifiedYn}
+                </if>
+                <!-- 인기회원 여부 필터링 -->
+                <if test="influencerYn != null and influencerYn != ''">
+                    AND ua.influencer_yn = #{influencerYn}
+                </if>
+                <!-- 가입상태 필터링 -->
+                <if test="userStatus != null and userStatus != ''">
+                    AND u.user_status = #{userStatus}
+                </if>
             </if>
         </where>
     </select>


### PR DESCRIPTION
🌟개요
--------------------
회원정보 전체 조회 및 정렬, 회원 검색 구현

🌐연결된 Issues
--------------------
#74 
#75 
#76 

📋작업사항
--------------------

회원의 이메일, 닉네임, 회원유형(일반/소셜-사이트), 사업자 인증여부, 가입일, 가입상태(탈퇴여부), 패널티 현황, 
등급, 등급포인트, 인기회원여부를 조회가능
사업자 인증여부, 인기회원여부, 패널티 여부로 필터링 및 가입일 및 포인트 순 정렬 구현 완료

기능이 기존 pr에 합쳐짐
- 관리자는 회원의 이메일, 닉네임으로 검색가능하다.
- 회원은 닉네임으로만 검색 가능하다.
- 관리자의 검색 시 결과는 회원 정보 전체조회 화면과 동일하게 모든 정보를 조회할 수 있다.
- 회원이 검색 시에는 닉네임, 등급이름, 인기회원 여부만 조회된다.

- 정렬 기준 수정, 필터링 조건 가입상태 추가

✏️작성한 이슈 외 작업사항
--------------------
이름 변경된 파일 있음.

✅체크리스트
---
- [x] PR 규칙을 준수하였는가?
- [x] 이슈번호를 작성하였는가?
- [x] 추가/수정 사항을 설명하였는가?
