### PR TITLE
feat: #212 리스트 댓글 좋아요 등록/취소 기능 구현

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/like/command/application/controller/ListCmtLikeController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/like/command/application/controller/ListCmtLikeController.java
@@ -1,0 +1,35 @@
+package com.matzip.matzipback.like.command.application.controller;
+
+import com.matzip.matzipback.like.command.application.dto.ListCmtLikeMessageDTO;
+import com.matzip.matzipback.like.command.application.dto.ListCmtLikeReqDTO;
+import com.matzip.matzipback.like.command.application.service.ListCmtLikeService;
+import com.matzip.matzipback.like.command.domain.aggregate.Like;
+import com.matzip.matzipback.responsemessage.ResponseMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ListCmtLikeController {
+
+    private final ListCmtLikeService listCmtLikeService;
+
+    @PostMapping("/listCmt/like")
+    public ResponseEntity<ListCmtLikeMessageDTO> saveListCmtLike(@Valid @RequestBody ListCmtLikeReqDTO listCmtLikeRequest){
+        Like resultLike = listCmtLikeService.saveAndDeleteListCmtLike(listCmtLikeRequest);
+
+        if (resultLike != null) {
+            return ResponseEntity.status(HttpStatus.CREATED).body(new ListCmtLikeMessageDTO(201, ResponseMessage.SAVE_SUCCESS.getMessage(), listCmtLikeRequest.getListCommentSeq()));
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(new ListCmtLikeMessageDTO(200, ResponseMessage.SAVE_FAIL.getMessage(), listCmtLikeRequest.getListCommentSeq()));
+    }
+
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/like/command/application/dto/ListCmtLikeMessageDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/like/command/application/dto/ListCmtLikeMessageDTO.java
@@ -1,0 +1,14 @@
+package com.matzip.matzipback.like.command.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class ListCmtLikeMessageDTO {
+
+    private int code;
+    private String message;
+    private Long listCommentSeq;
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/like/command/application/dto/ListCmtLikeReqDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/like/command/application/dto/ListCmtLikeReqDTO.java
@@ -1,0 +1,16 @@
+package com.matzip.matzipback.like.command.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ListCmtLikeReqDTO {
+
+    private Long likeUserSeq;
+    @NotNull
+    private Long listCommentSeq;
+
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/like/command/application/service/ListCmtLikeService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/like/command/application/service/ListCmtLikeService.java
@@ -1,0 +1,39 @@
+package com.matzip.matzipback.like.command.application.service;
+
+import com.matzip.matzipback.like.command.application.dto.ListCmtLikeReqDTO;
+import com.matzip.matzipback.like.command.domain.aggregate.Like;
+import com.matzip.matzipback.like.command.domain.service.ListCmtLikeDomainService;
+import com.matzip.matzipback.like.command.domain.service.ListLikeDomainService;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ListCmtLikeService {
+
+    private final ListCmtLikeDomainService listCmtLikeDomainService;
+    private final ModelMapper modelMapper;
+
+
+    @Transactional
+    public Like saveAndDeleteListCmtLike( ListCmtLikeReqDTO listCmtLikeRequest) {
+        // 인가받은 유저 seq 받아오기
+//        Long likeUserSeq = CustomUserUtils.getCurrentUserSeq();
+
+        long likeUserSeq = 4L;
+
+        Like foundListCmtLike = listCmtLikeDomainService.findLikeByLikeUserSeqAndListCmtSeq(likeUserSeq, listCmtLikeRequest.getListCommentSeq()).orElse(null);
+
+        if(foundListCmtLike == null) {
+            listCmtLikeRequest.setLikeUserSeq(likeUserSeq);
+            Like newListCmtLike = modelMapper.map(listCmtLikeRequest, Like.class);
+            return listCmtLikeDomainService.save(newListCmtLike);
+        }
+
+        listCmtLikeDomainService.delete(foundListCmtLike);
+        return null;
+    }
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/like/command/domain/repository/ListCmtLikeRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/like/command/domain/repository/ListCmtLikeRepository.java
@@ -1,0 +1,14 @@
+package com.matzip.matzipback.like.command.domain.repository;
+
+import com.matzip.matzipback.like.command.domain.aggregate.Like;
+
+import java.util.Optional;
+
+public interface ListCmtLikeRepository {
+
+    Optional<Like> findByLikeUserSeqAndListCommentSeq(long likeUserSeq, Long listCommentSeq);
+
+    void delete(Like foundListCmtLike);
+
+    Like save(Like newListCmtLike);
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/like/command/domain/service/ListCmtLikeDomainService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/like/command/domain/service/ListCmtLikeDomainService.java
@@ -1,0 +1,29 @@
+package com.matzip.matzipback.like.command.domain.service;
+
+import com.matzip.matzipback.like.command.domain.aggregate.Like;
+import com.matzip.matzipback.like.command.domain.repository.ListCmtLikeRepository;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ListCmtLikeDomainService {
+
+    private final ListCmtLikeRepository listCmtLikeRepository;
+
+    public Optional<Like> findLikeByLikeUserSeqAndListCmtSeq(long likeUserSeq, Long listCommentSeq) {
+        return listCmtLikeRepository.findByLikeUserSeqAndListCommentSeq(likeUserSeq, listCommentSeq);
+    }
+
+    // 좋아요 취소
+    public void delete(Like foundListCmtLike) {
+        listCmtLikeRepository.delete(foundListCmtLike);
+    }
+
+    public Like save(Like newListCmtLike) {
+        return listCmtLikeRepository.save(newListCmtLike);
+    }
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/like/command/infrastructure/repository/ListCmtLikeInfraRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/like/command/infrastructure/repository/ListCmtLikeInfraRepository.java
@@ -1,0 +1,10 @@
+package com.matzip.matzipback.like.command.infrastructure.repository;
+
+
+import com.matzip.matzipback.like.command.domain.aggregate.Like;
+import com.matzip.matzipback.like.command.domain.repository.ListCmtLikeRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ListCmtLikeInfraRepository extends JpaRepository<Like, Long>, ListCmtLikeRepository {
+
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/controller/ListCmtCommandController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/controller/ListCmtCommandController.java
@@ -2,6 +2,7 @@ package com.matzip.matzipback.matzipList.command.application.controller;
 
 import com.matzip.matzipback.matzipList.command.application.dto.CreateListCmtRequest;
 import com.matzip.matzipback.matzipList.command.application.dto.DeleteListCmtRequset;
+import com.matzip.matzipback.matzipList.command.application.dto.UpdateListCmtRequest;
 import com.matzip.matzipback.matzipList.command.application.service.ListCmtCommandService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +34,13 @@ public class ListCmtCommandController {
         listCmtCommandService.deleteListCmt(deleteListCmtRequset);
 
         return ResponseEntity.noContent().build();
+    }
+
+    // 리스트 댓글 수정
+    @PutMapping("/list/comment")
+    public ResponseEntity<Void> updateListCmt(@Valid @RequestBody UpdateListCmtRequest updateListCmtRequest){
+        Long listCmtSeq = listCmtCommandService.updateListCmt(updateListCmtRequest);
+
+        return ResponseEntity.created(URI.create("/api/v1/list/comment" + listCmtSeq)).build();
     }
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/dto/UpdateListCmtRequest.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/dto/UpdateListCmtRequest.java
@@ -1,0 +1,19 @@
+package com.matzip.matzipback.matzipList.command.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UpdateListCmtRequest {
+
+    @NotNull
+    private final Long listSeq;
+    @NotNull
+    private final Long listCommentSeq;
+    @NotBlank
+    private final String listCommentContent;
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/ListCmtCommandService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/ListCmtCommandService.java
@@ -3,10 +3,14 @@ package com.matzip.matzipback.matzipList.command.application.service;
 import com.matzip.matzipback.common.util.CustomUserUtils;
 import com.matzip.matzipback.matzipList.command.application.dto.CreateListCmtRequest;
 import com.matzip.matzipback.matzipList.command.application.dto.DeleteListCmtRequset;
+import com.matzip.matzipback.matzipList.command.application.dto.UpdateListCmtRequest;
 import com.matzip.matzipback.matzipList.command.domain.aggregate.MyListComment;
 import com.matzip.matzipback.matzipList.command.domain.repository.ListCmtDomainRepository;
+import com.matzip.matzipback.matzipList.command.domain.service.DomainListCmtUpdateService;
+import com.matzip.matzipback.matzipList.command.domain.service.DomainListUpdateService;
 import com.matzip.matzipback.matzipList.command.mapper.ListCmtMapper;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class ListCmtCommandService {
 
     private final ListCmtDomainRepository listCmtDomainRepository;
+    private final DomainListCmtUpdateService domainListCmtUpdateService;
 
     // 리스트 댓글 등록
     @Transactional
@@ -36,5 +41,16 @@ public class ListCmtCommandService {
     @Transactional
     public void deleteListCmt(DeleteListCmtRequset deleteListCmtRequset) {
         listCmtDomainRepository.deleteById(deleteListCmtRequset.getListCommentSeq());
+    }
+
+    // 리스트 댓글 수정
+    public Long updateListCmt(@Valid UpdateListCmtRequest updateListCmtRequest) {
+        //로그인한 사람의 유저 시퀀스를 가져오는 기능(권한이 들어있는 유저 시퀀스)
+//        Long listUserSeq = CustomUserUtils.getCurrentUserSeq();
+
+        // 테스트용 코드 생성
+        long listCmtUserSeq = 4L;
+
+        return domainListCmtUpdateService.updateListCmt(updateListCmtRequest, listCmtUserSeq);
     }
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/aggregate/MyListComment.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/aggregate/MyListComment.java
@@ -45,6 +45,11 @@ public class MyListComment {
     public static MyListComment create(Long listSeq, Long listCommentUserSeq, String listCommentContent) {
         return new MyListComment(listSeq, listCommentUserSeq, listCommentContent);
     }
+
+
+    public void updateListCommentContent(String listCommentContent) {
+        this.listCommentContent = listCommentContent;
+    }
 }
 
 

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/ListCmtDomainRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/ListCmtDomainRepository.java
@@ -4,6 +4,8 @@ import com.matzip.matzipback.matzipList.command.application.dto.DeleteListCmtReq
 import com.matzip.matzipback.matzipList.command.domain.aggregate.MyListComment;
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.Optional;
+
 public interface ListCmtDomainRepository {
 
 
@@ -11,4 +13,6 @@ public interface ListCmtDomainRepository {
 
 
     void deleteById(@NotBlank Long listCommentSeq);
+
+    Optional<MyListComment> findById(Long listCmtSeq);
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/service/DomainListCmtUpdateService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/service/DomainListCmtUpdateService.java
@@ -1,0 +1,31 @@
+package com.matzip.matzipback.matzipList.command.domain.service;
+
+import com.matzip.matzipback.matzipList.command.application.dto.UpdateListCmtRequest;
+import com.matzip.matzipback.matzipList.command.domain.aggregate.MyListComment;
+import com.matzip.matzipback.matzipList.command.domain.repository.ListCmtDomainRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DomainListCmtUpdateService {
+
+    private final ListCmtDomainRepository listCmtDomainRepository;
+    private final ModelMapper modelMapper;
+
+    public Long updateListCmt(@Valid UpdateListCmtRequest updateListCmtRequest, long listCmtUserSeq) {
+
+        Long listCmtSeq = updateListCmtRequest.getListCommentSeq();
+
+        MyListComment existListCmt = listCmtDomainRepository.findById(listCmtSeq).orElseThrow();
+
+        modelMapper.map(updateListCmtRequest, existListCmt);
+        existListCmt.updateListCommentContent(existListCmt.getListCommentContent());
+
+        listCmtDomainRepository.save(existListCmt);
+        return listCmtSeq;
+
+    }
+}


### PR DESCRIPTION
🌟개요
리스트 댓글 좋아요 등록/취소 기능 구현

🌐연결된 Issues
#212 

📋작업사항
리스트 댓글 좋아요를 등록, 취소할 수 있는 기능 구현
1. 좋아요가 존재하지 않을때 등록
2. 좋아요가 존재한다면 취소

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
