### PR TITLE
feat: #40 맛집 가져오기 기능 구현

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/exception/ErrorCode.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/exception/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
     /*
     * 409 DUPLICATE_ENTRY: 이미 값이 존재
     */
-    CONFLICT(HttpStatus.CONFLICT, "Date Conflict"),
+    CONFLICT(HttpStatus.CONFLICT, "Data Conflict"),
 
     /*
      * 500 INTERNAL_SERVER_ERROR: 내부 서버 오류

--- a/matzipback/src/main/java/com/matzip/matzipback/exception/ErrorCode.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/exception/ErrorCode.java
@@ -34,6 +34,11 @@ public enum ErrorCode {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Not allowed method."),
 
     /*
+    * 409 DUPLICATE_ENTRY: 이미 값이 존재
+    */
+    CONFLICT(HttpStatus.CONFLICT, "Date Conflict"),
+
+    /*
      * 500 INTERNAL_SERVER_ERROR: 내부 서버 오류
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Server error.");

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/controller/MatzipCollectCommandController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/controller/MatzipCollectCommandController.java
@@ -1,0 +1,34 @@
+package com.matzip.matzipback.matzipList.command.application.controller;
+
+import com.matzip.matzipback.exception.ErrorCode;
+import com.matzip.matzipback.exception.ErrorResponse;
+import com.matzip.matzipback.matzipList.command.application.dto.MatzipCollectReq;
+import com.matzip.matzipback.matzipList.command.application.service.MatzipCollectService;
+import com.matzip.matzipback.responsemessage.SuccessCode;
+import com.matzip.matzipback.responsemessage.SuccessResMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.service.GenericResponseService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MatzipCollectCommandController {
+
+    private final MatzipCollectService matzipCollectService;
+    private final GenericResponseService responseBuilder;
+
+    // 맛집 가져오기(등록)
+    @PostMapping("/list/matzip/collect")
+    public ResponseEntity<SuccessResMessage> collectMatzip(@Valid @RequestBody MatzipCollectReq matzipCollectReq){
+
+        Long listMatzipSeq = matzipCollectService.collectMatzip(matzipCollectReq);
+
+        return ResponseEntity.ok(new SuccessResMessage(SuccessCode.BASIC_SAVE_SUCCESS));
+    }
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/dto/MatzipCollectReq.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/dto/MatzipCollectReq.java
@@ -1,0 +1,17 @@
+package com.matzip.matzipback.matzipList.command.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MatzipCollectReq {
+
+    @NotNull(message = "리스트 고유번호가 null이면 안됩니다.")
+    private final Long listSeq;
+    @NotNull(message = "음식점 고유번호가 null이면 안됩니다.")
+    private final Long restaurantSeq;
+    private final String listMatzipComment;
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/MatzipCollectService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/MatzipCollectService.java
@@ -1,0 +1,49 @@
+package com.matzip.matzipback.matzipList.command.application.service;
+
+import com.matzip.matzipback.exception.ErrorCode;
+import com.matzip.matzipback.exception.RestApiException;
+import com.matzip.matzipback.matzipList.command.application.dto.MatzipCollectReq;
+import com.matzip.matzipback.matzipList.command.domain.aggregate.MyList;
+import com.matzip.matzipback.matzipList.command.domain.aggregate.MyListMatzip;
+import com.matzip.matzipback.matzipList.command.domain.repository.ListDomainRepository;
+import com.matzip.matzipback.matzipList.command.domain.repository.MatzipCollectDomainRepository;
+import com.matzip.matzipback.matzipList.command.domain.repository.MatzipDomainRepository;
+import io.jsonwebtoken.IncorrectClaimException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.jdbc.IncorrectResultSetColumnCountException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatzipCollectService {
+
+    private final MatzipCollectDomainRepository matzipCollectDomainRepository;
+    private final MatzipDomainRepository matzipDomainRepository;
+    private final ModelMapper modelMapper;
+    @Transactional
+    public Long collectMatzip(MatzipCollectReq matzipCollectReq) {
+
+        MyListMatzip collectMatzip = modelMapper.map(matzipCollectReq, MyListMatzip.class);
+
+        // 맛집 리스트에 해당 맛집이 존재하는지 검증
+        boolean ExistListMatzipSeq = matzipDomainRepository
+                .existsByRestaurantSeq(collectMatzip.getRestaurantSeq());
+        if (!ExistListMatzipSeq) {
+            throw new RestApiException(ErrorCode.BAD_REQUEST);
+        }
+
+        // 내 맛집 리스트에 이미 존재하는지 검증
+        boolean ExistMyListMatzipSeq = matzipDomainRepository
+                .existsByListSeqAndRestaurantSeq(collectMatzip.getListSeq(), collectMatzip.getRestaurantSeq());
+        if(ExistMyListMatzipSeq) {
+            throw new RestApiException(ErrorCode.CONFLICT);
+        }
+
+        MyListMatzip myMatzip = matzipCollectDomainRepository.save(collectMatzip);
+
+        return myMatzip.getListMatzipSeq();
+    }
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/aggregate/MyListMatzip.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/aggregate/MyListMatzip.java
@@ -1,6 +1,7 @@
 package com.matzip.matzipback.matzipList.command.domain.aggregate;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -45,4 +46,15 @@ public class MyListMatzip {
         this.listMatzipComment = listMatzipComment;
     }
 
+    public void createListSeq(@NotNull Long listSeq) {
+        this.listSeq = listSeq;
+    }
+
+    public void createRestaurantSeq(@NotNull Long restaurantSeq) {
+        this.restaurantSeq = restaurantSeq;
+    }
+
+    public void createListMatzipComment(String listMatzipComment) {
+        this.listMatzipComment = listMatzipComment;
+    }
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/MatzipCollectDomainRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/MatzipCollectDomainRepository.java
@@ -1,0 +1,13 @@
+package com.matzip.matzipback.matzipList.command.domain.repository;
+
+import com.matzip.matzipback.matzipList.command.domain.aggregate.MyListMatzip;
+
+import java.util.Optional;
+
+public interface MatzipCollectDomainRepository {
+
+    //Optional 객체 값 가져올때 비어있으면 NoSuchElementException 발생
+    Optional<MyListMatzip> findById(Long listSeq);
+
+    MyListMatzip save(MyListMatzip existMatzip);
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/MatzipDomainRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/MatzipDomainRepository.java
@@ -11,4 +11,8 @@ public interface MatzipDomainRepository {
     void deleteById(@NotBlank Long listMatzipSeq);
 
     Optional<MyListMatzip> findById(Long listMatzipSeq);
+
+    boolean existsByRestaurantSeq(Long restaurantSeq);
+
+    boolean existsByListSeqAndRestaurantSeq(Long listSeq, Long restaurantSeq);
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/infrastructure/repository/InfraMatzipCollectRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/infrastructure/repository/InfraMatzipCollectRepository.java
@@ -1,0 +1,8 @@
+package com.matzip.matzipback.matzipList.command.infrastructure.repository;
+
+import com.matzip.matzipback.matzipList.command.domain.aggregate.MyListMatzip;
+import com.matzip.matzipback.matzipList.command.domain.repository.MatzipCollectDomainRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InfraMatzipCollectRepository extends JpaRepository<MyListMatzip, Long>, MatzipCollectDomainRepository {
+}


### PR DESCRIPTION
🌟개요
맛집 가져오기 기능 구현

🌐연결된 Issues
#40 

📋작업사항
내가 추가하고 싶은
- 리스트 시퀀스
- 레스토랑 시퀀스
- 맛집 코멘트
를 입력받아서 추가하는 형식으로 구현

예외 처리
- 맛집 리스트에 등록된 레스토랑 리퀀스가 아닌경우 
- 이미 내 맛집 리스트에 등록된 맛집 인 경우

* 프론트에서 데이터를 넘길때 
1. 가져오고 싶은 맛집 선택 후 버튼 클릭
2. 코멘트 작성
3. 어떤 리스트에 추가할건지 선택

위의 과정을 생각하고 구성하였으며,
추가할 나의 맛집 리스트의 리스트 시퀀스,
다른 맛집 리스트에서 가져올 레스토랑 시퀀스, 
내가 추가할 맛집 코멘트를 입력받는 형식으로 구현했습니다.

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
