### PR TITLE
chore: #258 리스트 댓글 등록/삭제 시  점수 획득/차감 기능 구현

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/dto/DeleteListCmtRequset.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/dto/DeleteListCmtRequset.java
@@ -11,5 +11,5 @@ public class DeleteListCmtRequset {
     private Long listSeq;
     @NotNull
     private Long listCommentSeq;
-    private Long listCommentListSeq;
+    private Long listCommentUserSeq;
 }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/ListCmtCommandService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/ListCmtCommandService.java
@@ -9,6 +9,7 @@ import com.matzip.matzipback.matzipList.command.domain.repository.ListCmtDomainR
 import com.matzip.matzipback.matzipList.command.domain.service.DomainListCmtUpdateService;
 import com.matzip.matzipback.matzipList.command.domain.service.DomainListUpdateService;
 import com.matzip.matzipback.matzipList.command.mapper.ListCmtMapper;
+import com.matzip.matzipback.users.command.domain.service.UserActivityDomainService;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class ListCmtCommandService {
 
     private final ListCmtDomainRepository listCmtDomainRepository;
     private final DomainListCmtUpdateService domainListCmtUpdateService;
+    private final UserActivityDomainService userActivityDomainService;
 
     // 리스트 댓글 등록
     @Transactional
@@ -33,6 +35,9 @@ public class ListCmtCommandService {
 
         MyListComment MyListMatzipCmt = listCmtDomainRepository.save(newMyListMatzipCmt);
 
+        // 리스트 등록 시 점수 획득(1점)
+        userActivityDomainService.updateUserActivityPoint(listCommentUserSeq, 1);
+
         return MyListMatzipCmt.getListCommentSeq();
 
     }
@@ -41,6 +46,10 @@ public class ListCmtCommandService {
     @Transactional
     public void deleteListCmt(DeleteListCmtRequset deleteListCmtRequset) {
         listCmtDomainRepository.deleteById(deleteListCmtRequset.getListCommentSeq());
+
+        // 리스트 삭제 시 획득 점수 차감(-1점)
+        MyListComment commentUser = listCmtDomainRepository.findByListCommentSeq(deleteListCmtRequset.getListCommentSeq());
+        userActivityDomainService.updateUserActivityPoint(commentUser.getListCommentUserSeq(), -1);
     }
 
     // 리스트 댓글 수정

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/ListCmtCommandService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/application/service/ListCmtCommandService.java
@@ -27,9 +27,7 @@ public class ListCmtCommandService {
     @Transactional
     public Long createListCmt(CreateListCmtRequest listCmtRequest) {
         // 로그인한 사람의 유저 시퀀스를 가져오는 기능(권한이 들어있는 유저 시퀀스)
-//        Long listCommentUserSeq = CustomUserUtils.getCurrentUserSeq();
-
-        long listCommentUserSeq = 1L;
+        Long listCommentUserSeq = CustomUserUtils.getCurrentUserSeq();
 
         MyListComment newMyListMatzipCmt = ListCmtMapper.toEntity(listCmtRequest, listCommentUserSeq);
 
@@ -55,10 +53,9 @@ public class ListCmtCommandService {
     // 리스트 댓글 수정
     public Long updateListCmt(@Valid UpdateListCmtRequest updateListCmtRequest) {
         //로그인한 사람의 유저 시퀀스를 가져오는 기능(권한이 들어있는 유저 시퀀스)
-//        Long listUserSeq = CustomUserUtils.getCurrentUserSeq();
+        Long listCmtUserSeq = CustomUserUtils.getCurrentUserSeq();
 
-        // 테스트용 코드 생성
-        long listCmtUserSeq = 4L;
+
 
         return domainListCmtUpdateService.updateListCmt(updateListCmtRequest, listCmtUserSeq);
     }

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/ListCmtDomainRepository.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/command/domain/repository/ListCmtDomainRepository.java
@@ -3,6 +3,7 @@ package com.matzip.matzipback.matzipList.command.domain.repository;
 import com.matzip.matzipback.matzipList.command.application.dto.DeleteListCmtRequset;
 import com.matzip.matzipback.matzipList.command.domain.aggregate.MyListComment;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.Optional;
 
@@ -15,4 +16,7 @@ public interface ListCmtDomainRepository {
     void deleteById(@NotBlank Long listCommentSeq);
 
     Optional<MyListComment> findById(Long listCmtSeq);
+
+
+    MyListComment findByListCommentSeq(@NotNull Long listCommentSeq);
 }


### PR DESCRIPTION
🌟개요
리스트 댓글 등록 시  점수 획득/차감 기능 구현

🌐연결된 Issues
#258 

📋작업사항
리스트 댓글 등록 시 점수 1점 추가 기능 구현
리스트 댓글 삭제 시 점수 -1점 추가 기능 구현

✏️작성한 이슈 외 작업사항
DTO 변수명 수정

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
