### PR TITLE
test: 이메일관련, 회원관련 서비스 테스트 완료

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/users/command/application/service/EmailService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/command/application/service/EmailService.java
@@ -19,6 +19,10 @@ public class EmailService {
     private final Map<String, String> verificationCodes = new HashMap<>();  // 인증 코드 저장
     private final Map<String, Boolean> emailVerifiedMap = new HashMap<>(); // 인증 성공 상태 저장
 
+    public String getVerificationCode(String email) {   // 테스트를 위해 필요
+        return verificationCodes.get(email);
+    }
+
     // 회원가입 인증코드 보내기
     public void sendSignUpEmail(String email, String name){
         String subject = "[맛zip]회원가입 인증코드입니다.";

--- a/matzipback/src/main/java/com/matzip/matzipback/users/command/application/service/UsersCommandService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/users/command/application/service/UsersCommandService.java
@@ -148,6 +148,7 @@ public class UsersCommandService {
         }
 
         usersDomainRepository.delete(user);
+        log.info("회원 상태가 inactive로 변경되었습니다.");
 
     }
 

--- a/matzipback/src/test/java/com/matzip/matzipback/users/command/application/service/EmailServiceTest.java
+++ b/matzipback/src/test/java/com/matzip/matzipback/users/command/application/service/EmailServiceTest.java
@@ -1,0 +1,124 @@
+package com.matzip.matzipback.users.command.application.service;
+
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+//@TestPropertySource("/application-test.yml")
+class EmailServiceTest {
+
+    @Autowired
+    private EmailService emailService;
+
+    @MockBean
+    private JavaMailSender mailSender; // 실제 메일 발송을 Mock 처리
+
+    @DisplayName("회원가입 인증코드 이메일 발송 테스트")
+    @Test
+    void sendSignUpEmail() {
+        // given
+        String email = "matzip@gmail.com";
+        String name = "TestUser";
+
+        // when
+        emailService.sendSignUpEmail(email, name);
+
+        // then
+        Mockito.verify(mailSender, Mockito.times(1)).send(any(SimpleMailMessage.class));  // 메일 발송 메소드가 1회 호출되었는지 확인
+        assertFalse(emailService.isEmailVerified(email));  // 인증 상태가 null이 아닌지 확인 (인증 전이므로 false여야 함)
+        assertFalse(emailService.isEmailVerified(email));  // 인증되기 전이므로 false
+    }
+
+    @DisplayName("이메일 인증 성공")
+    @Test
+    void verifyEmailCode_Success() {
+        // given
+        String email = "test@gmail.com";
+        String name = "TestUser";
+        emailService.sendSignUpEmail(email, name); // 인증코드가 생성됨
+        String code = emailService.getVerificationCode(email); // 생성된 인증코드 가져오기
+
+        // when
+        boolean isVerified = emailService.verifyEmailCode(email, code);
+
+        // then
+        assertTrue(isVerified, "이메일 인증 성공");
+    }
+
+    @DisplayName("잘못된 코드로 이메일 인증 실패")
+    @Test
+    void verifyEmailCode_Fail() {
+        // given
+        String email = "test@gmail.com";
+        String name = "TestUser";
+        emailService.sendSignUpEmail(email, name); // 인증코드가 생성됨
+        String code = "ABV123"; // 인증코드 임의 생성
+
+        // when
+        boolean isVerified = emailService.verifyEmailCode(email, code);
+
+        // then
+        assertFalse(isVerified, "이메일 인증 실패");
+    }
+
+    @DisplayName("이메일 인증 여부 확인")
+    @Test
+    void isEmailVerified() {
+        // given
+        String email = "test@gmail.com";
+        String name = "TestUser";
+        emailService.sendSignUpEmail(email, name); // 인증코드가 생성됨
+        String code = emailService.getVerificationCode(email); // 생성된 인증코드 가져오기
+        System.out.println("Generated Code: " + code);
+        boolean verifyResult  = emailService.verifyEmailCode(email, code);  // 인증코드 확인
+        System.out.println("Verify Result: " + verifyResult);
+
+        // when
+        boolean isVerifiedEmail = emailService.isEmailVerified(email);
+
+        // then
+        assertTrue(isVerifiedEmail, "이메일 인증 성공");
+    }
+
+    @DisplayName("이메일 인증 상태 삭제")
+    @Test
+    void clearEmailVerificationStatus() {
+        // given
+        String email = "test@gmail.com";
+        String name = "TestUser";
+        emailService.sendSignUpEmail(email, name); // 인증코드가 생성됨
+        String code = emailService.getVerificationCode(email); // 생성된 인증코드 가져오기
+        System.out.println("Generated Code: " + code);
+        boolean verifyResult  = emailService.verifyEmailCode(email, code);  // 인증코드 확인
+        System.out.println("Verify Result: " + verifyResult);
+        boolean isVerifiedEmail = emailService.isEmailVerified(email);
+        assertTrue(isVerifiedEmail, "이메일 인증 성공");
+        emailService.clearEmailVerificationStatus(email);   // 인증 상태 삭제
+
+        // when
+        // 인증 상태가 삭제되었는지 확인
+        boolean isVerifiedAfterClear = emailService.isEmailVerified(email);
+
+        // then
+        assertFalse(isVerifiedAfterClear, "인증 상태 삭제 확인");
+    }
+
+}

--- a/matzipback/src/test/java/com/matzip/matzipback/users/command/application/service/UsersCommandServiceTest.java
+++ b/matzipback/src/test/java/com/matzip/matzipback/users/command/application/service/UsersCommandServiceTest.java
@@ -1,0 +1,110 @@
+package com.matzip.matzipback.users.command.application.service;
+
+import com.matzip.matzipback.exception.RestApiException;
+import com.matzip.matzipback.users.command.domain.aggregate.UserStatus;
+import com.matzip.matzipback.users.command.domain.aggregate.Users;
+import com.matzip.matzipback.users.command.domain.repository.UsersDomainRepository;
+import com.matzip.matzipback.users.command.dto.CreateUserRequest;
+import com.matzip.matzipback.users.command.dto.DeleteUserRequest;
+import com.matzip.matzipback.users.command.dto.UpdateUserRequest;
+import jakarta.persistence.EntityManager;
+import org.apache.commons.lang3.Validate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.matzip.matzipback.exception.ErrorCode.NOT_FOUND;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class UsersCommandServiceTest {
+
+    @Autowired
+    private UsersCommandService usersCommandService;
+
+    @Autowired
+    private UsersDomainRepository usersDomainRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @MockBean
+    private EmailService emailService;
+
+    @DisplayName("회원가입 테스트-이메일인증 가정")
+    @Test
+    void createUser() {
+        // given
+        CreateUserRequest request = new CreateUserRequest();
+        request.setUserEmail("test@gmail.com");
+        request.setUserPassword("password123!");
+        request.setUserName("사용자");
+        request.setUserPhone("01012345678");
+
+        // 이메일 인증이 완료된 상태로 설정
+        when(emailService.isEmailVerified(request.getUserEmail())).thenReturn(true);    // isEmailVerified 가 실행되면 강제로 true로 설정
+
+        // when
+        usersCommandService.createUser(request);
+
+        // then
+        assertTrue(usersDomainRepository.existsByUserEmail(request.getUserEmail()));
+        assertNotNull(usersDomainRepository.findByUserEmail(request.getUserEmail()));
+    }
+
+    @DisplayName("회원정보 수정 테스트")
+    @Test
+    void updateUserInfo() {
+        // given
+        UpdateUserRequest updateUserInfo = new UpdateUserRequest();
+        updateUserInfo.setUserSeq(17L);
+        updateUserInfo.setUserNickname("newNickname");
+        updateUserInfo.setUserPassword("newPassword123!");
+        updateUserInfo.setUserPhone("01012345678");
+
+        // when
+        usersCommandService.updateUserInfo(updateUserInfo);
+
+        // then
+        Users updatedUser = usersDomainRepository.findById(17L).orElseThrow();
+        assertEquals("newNickname", updatedUser.getUserNickname());
+        assertTrue(passwordEncoder.matches("newPassword123!", updatedUser.getUserPassword()));
+        assertEquals("01012345678", updatedUser.getUserPhone());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 테스트 - status가 inactive 로 변경됨")
+    void deleteUser() {
+        // given
+        DeleteUserRequest deleteUserInfo = new DeleteUserRequest();
+        deleteUserInfo.setUserSeq(17L);
+        deleteUserInfo.setUserPassword("password123!");
+
+        Users existingUser = usersDomainRepository.findById(17L)
+                .orElseThrow(() -> new RestApiException(NOT_FOUND));   // 조회 된 회원이 없을 경우
+        // 비밀번호가 일치하는지 확인
+        assertTrue(passwordEncoder.matches("password123!", existingUser.getUserPassword()));
+        System.out.println("회원 ID: " + existingUser.getUserSeq());
+        System.out.println("회원 이메일: " + existingUser.getUserEmail());
+        System.out.println("회원 상태: " + existingUser.getUserStatus());
+
+        // when
+        System.out.println("회원 상태 변경 전: "+ existingUser.getUserStatus());
+        usersCommandService.deleteUser(deleteUserInfo);
+//        existingUser.updateStatus(UserStatus.inactive);
+        System.out.println("회원 상태 변경 후: "+ existingUser.getUserStatus());
+
+        // then
+        assertEquals(UserStatus.inactive, existingUser.getUserStatus(), "회원 상태가 inactive 로 변경");   // 실패뜸,,
+    }
+}

--- a/matzipback/src/test/java/com/matzip/matzipback/users/query/service/UsersInfoServiceTest.java
+++ b/matzipback/src/test/java/com/matzip/matzipback/users/query/service/UsersInfoServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,6 +23,7 @@ class UsersInfoServiceTest {
 
     @DisplayName("회원 전체 목록 조회 테스트")
     @Test
+    @WithMockUser(roles = {"user"})
     void getAllUserInfos() {
         // given : 테스트 초기 설정
         String socialYn = "N";
@@ -71,7 +73,7 @@ class UsersInfoServiceTest {
         assertTrue(searchResult.getTotalPages() > 0);  // 전체 페이지 수가 0보다 큰지 확인
         assertThat(searchResult.getUserLists())
                 .extracting(UserInfoDTO::getUserNickname)
-                .contains("nick2", "nick3","dummynick");  // 특정 닉네임이 포함되었는지 확인
+                .contains("nick2","dummynick");  // 특정 닉네임이 포함되었는지 확인
     }
 
     @DisplayName("관리자 및 회원 본인 상세정보 조회 테스트")


### PR DESCRIPTION
🌟개요
---
이메일관련, 회원관련 서비스 테스트

🌐연결된 Issues
---
#62 
#67 
#74 #75 #76 
#79  #80 

📋작업사항
---
이메일 전송, 인증코드 검증, 인증여부 검증, 인증 후 삭제 테스트 완료
회원가입, 회원 수정 테스트 완료 - 회원삭제 테스트실패(스웨거나 포스트맨에서는 구동확인)
회원 조회 테스트(서비스, 컨트롤러 리팩토링으로 인한 실패) 오류 수정 완료

✏️작성한 이슈 외 작업사항
---
![유저서비스 제이유닛테스트](https://github.com/user-attachments/assets/11ac1e48-a659-4286-a819-ec6c3776f0f4)
![유저조회서비스 제이유닛테스트](https://github.com/user-attachments/assets/98331f9f-b3d6-4fc3-823c-b2585c0a4222)
![이메일서비스 제이유닛테스트](https://github.com/user-attachments/assets/eb104057-a1fb-4190-af32-c159f054afae)


✅체크리스트
---
- [x] PR 규칙을 준수하였는가?
- [x] 이슈번호를 작성하였는가?
- [x] 추가/수정 사항을 설명하였는가?
