### PR TITLE
feat: #331 리스트 댓글 조회 기능 구현

### DIFF
--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListCommentQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListCommentQueryController.java
@@ -22,7 +22,7 @@ public class ListCommentQueryController {
     private final ListCommentQueryService listCommentQueryService;
 
     // 리스트에 달린 댓글 조회(삭제되지 않은 댓글만 조회)
-    @GetMapping("/listbox/list/listCmt/{listSeq}")
+    @GetMapping("/listbox/list/{listSeq}/listCmt")
     @Operation(summary = "리스트 댓글 조회", description = "공개된 리스트 댓글을 조회한다.")
     public ResponseEntity<List<ListCommentDTO>> getListComments(@PathVariable("listSeq") Long listSeq){
         return ResponseEntity.ok().body(listCommentQueryService.getListComments(listSeq));

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListCommentQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListCommentQueryController.java
@@ -1,0 +1,30 @@
+package com.matzip.matzipback.matzipList.query.controller;
+
+import com.matzip.matzipback.matzipList.query.dto.ListCommentDTO;
+import com.matzip.matzipback.matzipList.query.service.ListCommentQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/back/api/v1")
+@Tag(name = "List", description = "리스트")
+public class ListCommentQueryController {
+
+    private final ListCommentQueryService listCommentQueryService;
+
+    // 리스트에 달린 댓글 조회(삭제되지 않은 댓글만 조회)
+    @GetMapping("/listbox/list/listCmt/{listSeq}")
+    @Operation(summary = "리스트 댓글 조회", description = "공개된 리스트 댓글을 조회한다.")
+    public ResponseEntity<List<ListCommentDTO>> getListComments(@PathVariable("listSeq") Long listSeq){
+        return ResponseEntity.ok().body(listCommentQueryService.getListComments(listSeq));
+    }
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/ListQueryController.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/back/api/vi")
+@RequestMapping("/back/api/v1")
 @Tag(name = "List", description = "리스트")
 public class ListQueryController {
 

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/MatzipQueryController.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/controller/MatzipQueryController.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/back/api/vi")
+@RequestMapping("/back/api/v1")
 @Tag(name = "List", description = "리스트")
 public class MatzipQueryController {
 

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/dto/ListCommentDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/dto/ListCommentDTO.java
@@ -1,0 +1,11 @@
+package com.matzip.matzipback.matzipList.query.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ListCommentDTO {
+    private Long listCommentUserSeq;
+    private String listCommentContent;
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/dto/ListCommentSearchDTO.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/dto/ListCommentSearchDTO.java
@@ -1,0 +1,14 @@
+package com.matzip.matzipback.matzipList.query.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ListCommentSearchDTO {
+
+    private String userNickname;
+    private String listCommentContent;
+    private String listCommentUpdatedTime;
+    private Long likeCount;
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/mapper/ListCommentQueryMapper.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/mapper/ListCommentQueryMapper.java
@@ -1,0 +1,12 @@
+package com.matzip.matzipback.matzipList.query.mapper;
+
+import com.matzip.matzipback.matzipList.query.dto.ListCommentDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface ListCommentQueryMapper {
+
+    List<ListCommentDTO> getListComments(Long listSeq);
+}

--- a/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/service/ListCommentQueryService.java
+++ b/matzipback/src/main/java/com/matzip/matzipback/matzipList/query/service/ListCommentQueryService.java
@@ -1,0 +1,20 @@
+package com.matzip.matzipback.matzipList.query.service;
+
+import com.matzip.matzipback.matzipList.query.dto.ListCommentDTO;
+import com.matzip.matzipback.matzipList.query.mapper.ListCommentQueryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ListCommentQueryService {
+
+    private final ListCommentQueryMapper listCommentQueryMapper;
+
+
+    public List<ListCommentDTO> getListComments(Long listSeq) {
+        return listCommentQueryMapper.getListComments(listSeq);
+    }
+}

--- a/matzipback/src/main/resources/mappers/listMappers/ListCommentQueryMapper.xml
+++ b/matzipback/src/main/resources/mappers/listMappers/ListCommentQueryMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.matzip.matzipback.matzipList.query.mapper.ListCommentQueryMapper">
+
+    <select  id="getListComments" resultType="com.matzip.matzipback.matzipList.query.dto.ListCommentSearchDTO">
+        SELECT
+                u.user_nickname,
+                lc.list_comment_content,
+                lc.list_comment_updated_time,
+                (SELECT COUNT(*) FROM `like` k WHERE k.list_comment_seq = lc.list_comment_seq) AS like_count
+        FROM
+                list_comment lc
+        LEFT JOIN users u ON lc.list_comment_user_seq = u.user_seq
+        LEFT JOIN lists l ON lc.list_seq = l.list_seq
+        WHERE
+                l.list_seq = #{listSeq}
+                AND lc.list_comment_status = 'active'
+        ORDER BY
+                lc.list_comment_updated_time DESC;
+    </select>
+
+
+</mapper>


### PR DESCRIPTION
🌟개요
리스트 댓글 조회 기능 구현

🌐연결된 Issues
#331 

📋작업사항
리스트에 등록된 댓글을 조회하는 기능 구현
+ 작성자 닉네임
+ 작성 댓글 내용
+ 서브쿼리로 like 집계
+ 업데이트 날짜(최신순으로 정렬)

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
