### PR TITLE
feat: 회원 활동 등급 수정, 삭제 기능 (관리자 기능)

### DIFF
--- a/matzipuser/src/main/java/com/matzip/matzipuser/exception/ErrorCode.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/exception/ErrorCode.java
@@ -49,7 +49,10 @@ public enum ErrorCode {
     /*
      * 500 INTERNAL_SERVER_ERROR: 내부 서버 오류
      */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Server error.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Server error."),
+
+    /* 저장 실패 */
+    NOT_UPDATED(HttpStatus.CONFLICT, "Not updated.");
 
 
     private final HttpStatus httpStatus;

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/controller/ActiveLevelController.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/controller/ActiveLevelController.java
@@ -1,10 +1,11 @@
 package com.matzip.matzipuser.users.command.application.controller;
 
+import com.matzip.matzipuser.exception.ErrorCode;
+import com.matzip.matzipuser.exception.RestApiException;
 import com.matzip.matzipuser.responsemessage.ResponseMessage;
-import com.matzip.matzipuser.users.command.application.dto.ActiveLevelResDTO;
-import com.matzip.matzipuser.users.command.application.dto.CreateActiveLevelRequestDTO;
-import com.matzip.matzipuser.users.command.application.dto.CreateActiveLevelResMessageDTO;
-import com.matzip.matzipuser.users.command.application.dto.UpdateUserActivityPointDTO;
+import com.matzip.matzipuser.responsemessage.SuccessCode;
+import com.matzip.matzipuser.responsemessage.SuccessResMessage;
+import com.matzip.matzipuser.users.command.application.dto.*;
 import com.matzip.matzipuser.users.command.application.service.ActiveLevelService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,16 +27,34 @@ public class ActiveLevelController {
     // active-level 저장
     @PostMapping("/active-level")
     @Operation(summary = "회원 활동 등급 등록", description = "회원 활동 등급을 등록한다.")
-    public ResponseEntity<CreateActiveLevelResMessageDTO> saveActiveLevel(@RequestBody CreateActiveLevelRequestDTO createActiveLevelRequestDTO) {
-        ActiveLevelResDTO savedActiveLevel = activeLevelService.saveActiveLevel(createActiveLevelRequestDTO);
+    public ResponseEntity<SuccessResMessage> saveActiveLevel(@RequestBody CreateActiveLevelRequestDTO createActiveLevelRequestDTO) {
+        boolean result = activeLevelService.saveActiveLevel(createActiveLevelRequestDTO);
 
         // 저장 실패
-        if (savedActiveLevel == null) {
-            return ResponseEntity.ok(new CreateActiveLevelResMessageDTO(HttpStatus.OK.value(), ResponseMessage.SAVE_FAIL.getMessage(), null));
+        if (!result) {
+            throw new RestApiException(ErrorCode.NOT_SAVED);
         }
 
         // 저장 성공
-        return ResponseEntity.ok(new CreateActiveLevelResMessageDTO(HttpStatus.OK.value(), ResponseMessage.SAVE_SUCCESS.getMessage(), List.of(savedActiveLevel)));
+        return ResponseEntity.ok(new SuccessResMessage(SuccessCode.BASIC_SAVE_SUCCESS));
+    }
+
+    @PutMapping("/active-level")
+    @Operation(summary = "회원 활동 등급 수정", description = "회원 활동 등급을 수정한다.")
+    public ResponseEntity<SuccessResMessage> updateActiveLevel(
+            @RequestBody UpdateActiveLevelDTO updateActiveLevelDTO) {
+
+        activeLevelService.updateActiveLevel(updateActiveLevelDTO);
+
+        return ResponseEntity.ok(new SuccessResMessage(SuccessCode.BASIC_UPDATE_SUCCESS));
+    }
+
+    @DeleteMapping("/active-level/{activeLevelSeq}")
+    @Operation(summary = "회원 활동 등급을 삭제", description = "회원 활동 등급을 삭제한다.")
+    public ResponseEntity<SuccessResMessage> deleteActiveLevel(@PathVariable Long activeLevelSeq) {
+
+        activeLevelService.deleteActiveLevel(activeLevelSeq);
+        return ResponseEntity.ok(new SuccessResMessage(SuccessCode.BASIC_DELETE_SUCCESS));
     }
 
     // userActivity point 업데이트

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/UpdateActiveLevelDTO.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/dto/UpdateActiveLevelDTO.java
@@ -1,0 +1,15 @@
+package com.matzip.matzipuser.users.command.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class UpdateActiveLevelDTO {
+
+    private Long activeLevelSeq;
+    private String activeLevelName;
+    private Integer activeLevelStandard;
+}

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/service/ActiveLevelService.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/application/service/ActiveLevelService.java
@@ -1,8 +1,8 @@
 package com.matzip.matzipuser.users.command.application.service;
 
+import com.matzip.matzipuser.users.command.application.dto.UpdateActiveLevelDTO;
 import com.matzip.matzipuser.users.command.application.dto.UpdateUserActivityPointDTO;
 import com.matzip.matzipuser.users.command.domain.service.ActiveLevelDomainService;
-import com.matzip.matzipuser.users.command.application.dto.ActiveLevelResDTO;
 import com.matzip.matzipuser.users.command.application.dto.CreateActiveLevelRequestDTO;
 import com.matzip.matzipuser.users.command.domain.service.UserActivityDomainService;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +16,28 @@ public class ActiveLevelService {
     private final ActiveLevelDomainService activeLevelDomainService;
     private final UserActivityDomainService userActivityDomainService;
 
+    // 등급 레벨 엔티티 저장
     @Transactional
-    public ActiveLevelResDTO saveActiveLevel(CreateActiveLevelRequestDTO createActiveLevelRequestDTO) {
+    public boolean saveActiveLevel(CreateActiveLevelRequestDTO createActiveLevelRequestDTO) {
         return activeLevelDomainService.saveActiveLevel(createActiveLevelRequestDTO);
     }
 
+    // 회원의 포인트 수정
+    @Transactional
     public void updateUserPoint(UpdateUserActivityPointDTO updateUserActivityPointDTO) {
         userActivityDomainService.updateUserActivityPoint(updateUserActivityPointDTO);
+    }
+
+    // 활동 등급 수정
+    @Transactional
+    public void updateActiveLevel(UpdateActiveLevelDTO updateActiveLevelDTO) {
+        activeLevelDomainService.updateActiveLevel(updateActiveLevelDTO);
+    }
+
+    // 활동 등급 삭제
+    @Transactional
+    public void deleteActiveLevel(Long activeLevelSeq) {
+
+        activeLevelDomainService.deleteActiveLevel(activeLevelSeq);
     }
 }

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/domain/repository/UserActiveLevelRepository.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/domain/repository/UserActiveLevelRepository.java
@@ -3,9 +3,14 @@ package com.matzip.matzipuser.users.command.domain.repository;
 import com.matzip.matzipuser.users.command.domain.aggregate.ActiveLevel;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserActiveLevelRepository {
     List<ActiveLevel> findAll();
 
     ActiveLevel save(ActiveLevel newActiveLevel);
+
+    Optional<ActiveLevel> findById(Long activeLevelSeq);
+
+    void deleteById(Long activeLevelSeq);
 }

--- a/matzipuser/src/main/java/com/matzip/matzipuser/users/command/domain/service/ActiveLevelDomainService.java
+++ b/matzipuser/src/main/java/com/matzip/matzipuser/users/command/domain/service/ActiveLevelDomainService.java
@@ -1,8 +1,10 @@
 package com.matzip.matzipuser.users.command.domain.service;
 
+import com.matzip.matzipuser.exception.ErrorCode;
+import com.matzip.matzipuser.exception.RestApiException;
+import com.matzip.matzipuser.users.command.application.dto.UpdateActiveLevelDTO;
 import com.matzip.matzipuser.users.command.domain.aggregate.ActiveLevel;
 import com.matzip.matzipuser.users.command.domain.repository.UserActiveLevelRepository;
-import com.matzip.matzipuser.users.command.application.dto.ActiveLevelResDTO;
 import com.matzip.matzipuser.users.command.application.dto.CreateActiveLevelRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -23,11 +25,27 @@ public class ActiveLevelDomainService {
         return userActiveLevelRepository.findAll();
     }
 
-    public ActiveLevelResDTO saveActiveLevel(CreateActiveLevelRequestDTO createActiveLevelRequestDTO) {
+    public boolean saveActiveLevel(CreateActiveLevelRequestDTO createActiveLevelRequestDTO) {
         ActiveLevel newActiveLevel = modelMapper.map(createActiveLevelRequestDTO, ActiveLevel.class);
 
         ActiveLevel savedActiveLevel = userActiveLevelRepository.save(newActiveLevel);
 
-        return modelMapper.map(savedActiveLevel, ActiveLevelResDTO.class);
+        return savedActiveLevel != null;
+    }
+
+    // 활동 등급 수정
+    public void updateActiveLevel(UpdateActiveLevelDTO updateActiveLevelDTO) {
+
+        ActiveLevel foundActiveLevel = userActiveLevelRepository
+                .findById(updateActiveLevelDTO.getActiveLevelSeq())
+                .orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND));
+
+        modelMapper.map(updateActiveLevelDTO, foundActiveLevel);
+    }
+
+    // 활동 등급 삭제
+    public void deleteActiveLevel(Long activeLevelSeq) {
+
+        userActiveLevelRepository.deleteById(activeLevelSeq);
     }
 }


### PR DESCRIPTION
🌟개요
---
회원 활동 등급 수정, 삭제 기능 (관리자 기능)

🌐연결된 Issues
---
#344 

📋작업사항
---
- 회원 활동 등급 수정, 삭제 기능 -> 관리자 기능
- 수정을 위한 DTO 객체 추가
- 회원 활등 등급 저장하는 로직 리팩토링

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [x] PR 규칙을 준수하였는가?
- [x] 이슈번호를 작성하였는가?
- [x] 추가/수정 사항을 설명하였는가?
